### PR TITLE
Removes padding override from theme

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -82,21 +82,6 @@ h6 {
 }
 
 /* 03 - LINKS */
-.btn-primary,
-.btn-secondary,
-.btn-default {
-  width: 100%;
-  padding: 10px 15px;
-  font-size: 18px;
-}
-
-@media screen and (min-width: 640px) {
-  .btn-primary,
-  .btn-secondary,
-  .btn-default {
-    width: auto;
-  }
-}
 
 a {
   color: $linkColor;


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/2367

The theme shouldn’t have a static value setting, that doesn’t come from the user.

Also, this button style override already exists in `bootstrap.css`.