### PR TITLE
Simplifies configurations for tables

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -112,24 +112,33 @@ a {
 }
 
 /* 04 - TABLES */
-table {
-  border-top: $tableBorderTop;
-  border-right: $tableBorderRight;
-  border-bottom: $tableBorderBottom;
-  border-left: $tableBorderLeft;
 
-  tr {
-    border-top: $rowBorderTop;
-    border-right: $rowBorderRight;
-    border-bottom: $rowBorderBottom;
-    border-left: $rowBorderLeft;
-  }
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  padding: $cellPadding;
+}
 
-  td {
+.table-bordered > thead > tr > th,
+.table-bordered > tbody > tr > th,
+.table-bordered > tfoot > tr > th,
+.table-bordered > thead > tr > td,
+.table-bordered > tbody > tr > td,
+.table-bordered > tfoot > tr > td {
+  border: $cellBorderTop;
+}
+
+table,
+table.mce-item-table {
+
+  th,
+  td,
+  caption {
     padding: $cellPadding;
-    border-top: $cellBorderTop;
-    border-right: $cellBorderRight;
-    border-bottom: $cellBorderBottom;
-    border-left: $cellBorderLeft;
+    border: $cellBorderTop;
   }
 }
+

--- a/theme.json
+++ b/theme.json
@@ -716,14 +716,14 @@
             "description": "Primary button border",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "primaryButtonBorderRadius",
             "description": "Primary button border radius",
             "type": "text",
             "default": "6px",
-            "hint": "e.g.: 6px 6px 6px 6px"
+            "hint": "e.g. 6px 6px 6px 6px"
           },
           {
             "name": "primaryButtonHoverColor",
@@ -742,7 +742,7 @@
             "description": "Primary button border when clicked",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "secondaryButtonColor",
@@ -761,14 +761,14 @@
             "description": "Secondary button border",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "secondaryButtonBorderRadius",
             "description": "Secondary button border radius",
             "type": "text",
             "default": "6px",
-            "hint": "e.g.: 6px 6px 6px 6px"
+            "hint": "e.g. 6px 6px 6px 6px"
           },
           {
             "name": "secondaryButtonHoverColor",
@@ -787,7 +787,7 @@
             "description": "Secondary button border when clicked",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           }
         ]
       },
@@ -971,7 +971,7 @@
             "description": "List item separator line",
             "type": "text",
             "default": "1px solid rgba(51, 51, 51, 0.2)",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "directoryListChevronColor",
@@ -1145,7 +1145,7 @@
             "description": "Directory details top bar border (mobile)",
             "type": "text",
             "default": "1px solid #c9c9c9",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "directoryOverlayContentColor",
@@ -1236,28 +1236,28 @@
             "description": "Text fields border",
             "type": "text",
             "default": "1px solid #e5e5e5",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "formInputBorderRadius",
             "description": "Text fields border radius",
             "type": "text",
             "default": "6px",
-            "hint": "e.g.: 6px 6px 6px 6px"
+            "hint": "e.g. 6px 6px 6px 6px"
           },
           {
             "name": "formInputBorderFocus",
             "description": "Text fields border when active",
             "type": "text",
             "default": "1px solid #337ab7",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "formInputBorderError",
             "description": "Text fields border with error",
             "type": "text",
             "default": "1px solid #a94442",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "formToggleBackgroundColor",
@@ -1270,7 +1270,7 @@
             "description": "Single & multiple choice border",
             "type": "text",
             "default": "1px solid #e5e5e5",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "formToggleColor",
@@ -1390,7 +1390,7 @@
             "description": "List item separator line",
             "type": "text",
             "default": "1px solid rgba(51, 51, 51, 0.2)",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "listChevronColor",
@@ -1457,7 +1457,7 @@
             "description": "PDF file list search border",
             "type": "text",
             "default": "2px solid #337ab7",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "listSearchCancel",
@@ -1487,14 +1487,14 @@
             "description": "Input fields border",
             "type": "text",
             "default": "1px solid rgba(0,0,0,0.3)",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "lockInputFocus",
             "description": "Input fields border when active",
             "type": "text",
             "default": "1px solid #337ab7",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "lockChevronColor",
@@ -1507,7 +1507,7 @@
             "description": "Touch ID button border",
             "type": "text",
             "default": "1px solid rgba(0,0,0,0.3)",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           }
         ]
       },
@@ -1519,14 +1519,14 @@
             "description": "Input fields border",
             "type": "text",
             "default": "1px solid #e5e5e5",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "fieldBorderRadius",
             "description": "Input fields border radius",
             "type": "text",
             "default": "6px",
-            "hint": "e.g.: 6px 6px 6px 6px"
+            "hint": "e.g. 6px 6px 6px 6px"
           },
           {
             "name": "chevronColor",
@@ -1539,7 +1539,7 @@
             "description": "Separator between back button and input text",
             "type": "text",
             "default": "1px solid #337ab7",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           }
         ]
       },
@@ -1629,7 +1629,7 @@
             "description": "Pagination dots border",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "onboardingPaginationBulletColorActive",
@@ -1642,7 +1642,7 @@
             "description": "Pagination active dots border",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "onboardingPaginationChevronsBgColor",
@@ -1708,14 +1708,14 @@
             "description": "Panel border",
             "type": "text",
             "default": "1px solid #e0e0e0",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "panelBorderRadius",
             "description": "Panel border radius",
             "type": "text",
             "default": "6px",
-            "hint": "e.g.: 6px 6px 6px 6px"
+            "hint": "e.g. 6px 6px 6px 6px"
           }
         ]
       },
@@ -1727,7 +1727,7 @@
             "description": "Photo container border",
             "type": "text",
             "default": "1px solid #cccccc",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "imageOverlayBackgroundColor",
@@ -1870,7 +1870,7 @@
             "description": "Pagination dots border",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "paginationBulletColorActive",
@@ -1883,7 +1883,7 @@
             "description": "Pagination active dots border",
             "type": "text",
             "default": "none",
-            "hint": "e.g.: 1px solid transparent"
+            "hint": "e.g. 1px solid transparent"
           },
           {
             "name": "paginationChevronsColor",
@@ -1897,95 +1897,18 @@
         "name": "Tables",
         "variables": [
           {
-            "name": "tableBorderTop",
-            "description": "Table border top",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "tableBorderRight",
-            "description": "Table border right",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "tableBorderBottom",
-            "description": "Table border bottom",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "tableBorderLeft",
-            "description": "Table border left",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "rowBorderTop",
-            "description": "Table row border top",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "rowBorderRight",
-            "description": "Table row border right",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "rowBorderBottom",
-            "description": "Table row border bottom",
-            "type": "text",
-            "default": "1px solid #cccccc",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "rowBorderLeft",
-            "description": "Table row border left",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
             "name": "cellBorderTop",
-            "description": "Table cell border top",
+            "description": "Table cell border",
             "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "cellBorderRight",
-            "description": "Table cell border right",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "cellBorderBottom",
-            "description": "Table cell border bottom",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
-          },
-          {
-            "name": "cellBorderLeft",
-            "description": "Table cell border left",
-            "type": "text",
-            "default": "none",
-            "hint": "e.g.: 1px solid #cccccc"
+            "default": "1px solid #dddddd",
+            "hint": "e.g. 1px solid #cccccc"
           },
           {
             "name": "cellPadding",
             "description": "Table cell padding",
             "type": "text",
-            "default": "0px",
-            "hint": "e.g.: 5px 5px 5px 5px"
+            "default": "8px",
+            "hint": "e.g. 5px 5px 5px 5px"
           }
         ]
       }


### PR DESCRIPTION
This resolves the following problems:

- There are too many settings for tables
   - No user has needed to apply different border styles to the 4 sides (top, bottom, left, right).
   - No user has needed to apply different border styles to table or table rows. They are most likely just changing the border color

It also adds styling support for class-less tables following https://github.com/Fliplet/fliplet-api/pull/2823