### PR TITLE
Makes sure search and filter UI are correctly themed

### DIFF
--- a/scss/components/lists-data-source.scss
+++ b/scss/components/lists-data-source.scss
@@ -250,6 +250,7 @@
   }
 
   .hidden-search-controls .current-query-wrapper {
+    border-color: $primaryButtonColor;
     background-color: $primaryButtonColor;
     color: $primaryButtonTextColor;
 
@@ -272,6 +273,7 @@
     }
 
     &.mixitup-control-active {
+      border-color: $primaryButtonColor;
       background-color: $primaryButtonColor;
       color: $primaryButtonTextColor;
 

--- a/scss/components/lists-data-source.scss
+++ b/scss/components/lists-data-source.scss
@@ -221,6 +221,10 @@
     .form-control {
       background-color: $bodyBackground;
       color: $bodyTextColor;
+
+      &:focus {
+        border-color: $primaryButtonColor;
+      }
     }
     .btn.search-btn {
       border: none;

--- a/scss/components/lists-data-source.scss
+++ b/scss/components/lists-data-source.scss
@@ -194,7 +194,7 @@
       color: $primaryButtonTextColor;
       border-color: $primaryButtonColor;
     }
-  } 
+  }
 
   .filter-holder {
     .panel-default > .panel-heading {
@@ -249,6 +249,16 @@
     }
   }
 
+  .hidden-search-controls .current-query-wrapper {
+    background-color: $primaryButtonColor;
+    color: $primaryButtonTextColor;
+
+    &:hover,
+    &:focus {
+      color: rgba($primaryButtonTextColor, 0.7);
+    }
+  }
+
   .hidden-filter-controls-label {
     color: rgba($bodyTextColor, 0.5);
   }
@@ -259,6 +269,16 @@
     &:hover,
     &:focus {
       color: rgba($bodyTextColor, 0.7);
+    }
+
+    &.mixitup-control-active {
+      background-color: $primaryButtonColor;
+      color: $primaryButtonTextColor;
+
+      &:hover,
+      &:focus {
+        color: rgba($primaryButtonTextColor, 0.7);
+      }
     }
   }
 }
@@ -291,7 +311,7 @@
       .news-feed-item-content {
         background-color: $lfdBackgroundColor;
       }
-    } 
+    }
   }
 
   .news-feed-item-content {


### PR DESCRIPTION
Resolves the following problems, where the blue buttons/borders should be in dark navy:

![image](https://user-images.githubusercontent.com/290733/53979419-b5aa7580-4105-11e9-8d67-1c4cf1c98e9f.png)

![image](https://user-images.githubusercontent.com/290733/53980139-7e3cc880-4107-11e9-9a3b-36b398fdeef4.png)
