### PR TITLE
fixes links color in bubbles

### DIFF
--- a/scss/components/chat.scss
+++ b/scss/components/chat.scss
@@ -187,6 +187,10 @@
       border: 1px solid transparent;
       color: $chatOwnBubbleTextColor;
 
+      a {
+        color: $chatOwnBubbleTextColor;
+      }
+
       &:after {
         border-color: transparent transparent transparent $chatOwnBubbleBackground;
       }
@@ -198,6 +202,10 @@
       background-color: $chatOthersBubbleBackground;
       border: 1px solid transparent;
       color: $chatOthersBubbleTextColor;
+
+      a {
+        color: $chatOthersBubbleTextColor;
+      }
 
       &:after {
         border-color: transparent $chatOthersBubbleBackground transparent transparent;
@@ -233,6 +241,10 @@
       .chat-body {
         background-color: #fff2be;
         color: $chatTextColor;
+
+        a {
+          color: $chatTextColor;
+        }
 
         &:after {
           border-color: transparent transparent transparent #fff2be;


### PR DESCRIPTION
Issue reported by @ibroom on LMA app where links posted on blue colored bubbles are invisible.