### PR TITLE
Fix input color on search field

### DIFF
--- a/scss/components/interactive-graphics.scss
+++ b/scss/components/interactive-graphics.scss
@@ -46,6 +46,7 @@
 .interactive-map-overlay-search-holder {
   .form-control {
     background: $mapSearchOverlayBackground;
+    color: $mapSearchOverlayText;
     border-color: $mapSearchOverlayText;
   }
 


### PR DESCRIPTION
<img width="368" alt="Screenshot 2019-05-10 at 13 31 13" src="https://user-images.githubusercontent.com/7046481/57527844-965bde80-7328-11e9-9d7a-128389e1b5d1.png">

To be released with: https://github.com/Fliplet/fliplet-widget-interactive-map/pull/38