### PR TITLE
Missing properties for form labels

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -228,6 +228,8 @@
           font-size: map-get($configuration, formLabelSize);
           font-family: map-get($configuration, formLabelFontFam);
           font-weight: map-get($configuration, formLabelWeight);
+          font-style: map-get($configuration, formLabelStyle);
+          text-decoration: map-get($configuration, formLabelDecoration);
 
           // Styles for tablet
           @include above($tabletBreakpoint) {
@@ -235,6 +237,8 @@
             font-size: map-get($configuration, formLabelSizeTablet);
             font-family: map-get($configuration, formLabelFontFamTablet);
             font-weight: map-get($configuration, formLabelWeightTablet);
+            font-style: map-get($configuration, formLabelStyleTablet);
+            text-decoration: map-get($configuration, formLabelDecorationTablet);
           }
 
           // Styles for desktop
@@ -243,6 +247,8 @@
             font-size: map-get($configuration, formLabelSizeDesktop);
             font-family: map-get($configuration, formLabelFontFamDesktop);
             font-weight: map-get($configuration, formLabelWeightDesktop);
+            font-style: map-get($configuration, formLabelStyleDesktop);
+            text-decoration: map-get($configuration, formLabelDecorationDesktop);
           }
         }
       }


### PR DESCRIPTION
For the following: https://github.com/Fliplet/fliplet-studio/issues/4576

There were some missing properties for the form labels.