### PR TITLE
Adds a hidden configuration to contain old variables

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -31009,6 +31009,36 @@
             ]
           }
         ]
+      },
+      {
+        "name": "Migration",
+        "hide": true,
+        "variables": [
+          {
+            "name": "headingOneFont",
+            "default": "$headingOneFontFamily"
+          },
+          {
+            "name": "headingTwoFont",
+            "default": "$headingTwoFontFamily"
+          },
+          {
+            "name": "headingThreeFont",
+            "default": "$headingThreeFontFamily"
+          },
+          {
+            "name": "headingFourFont",
+            "default": "$headingFourFontFamily"
+          },
+          {
+            "name": "headingFiveFont",
+            "default": "$headingFiveFontFamily"
+          },
+          {
+            "name": "headingSixFont",
+            "default": "$headingSixFontFamily"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4670

This PR adds a hidden configuration that the sole purpose is to make available to custom SCSS the old variables from the previous theme version.