### PR TITLE
Fixes defaults for menus

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -3444,7 +3444,7 @@
             "fields": [
               {
                 "name": "menuPushFont",
-                "default": "$bodyFontFamily",
+                "default": "$menuFont",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3469,7 +3469,7 @@
               },
               {
                 "name": "menuPushFontSize",
-                "default": "16px",
+                "default": "$menuFontSize",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3495,7 +3495,7 @@
               },
               {
                 "name": "menuPushTopNavFontColor",
-                "default": "$bodyTextColor",
+                "default": "$menuTopNavFontColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3524,7 +3524,7 @@
               },
               {
                 "name": "menuPushFontWeight",
-                "default": "normal",
+                "default": "$menuFontWeight",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3550,7 +3550,7 @@
               },
               {
                 "name": "menuPushFontStyle",
-                "default": "normal",
+                "default": "$menuFontStyle",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3576,7 +3576,7 @@
               },
               {
                 "name": "menuPushFontDecoration",
-                "default": "none",
+                "default": "$menuFontDecoration",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3608,7 +3608,7 @@
             "fields": [
               {
                 "name": "menuPushTopNavBackground",
-                "default": "rgba(255, 255, 255, 0.85)",
+                "default": "$menuTopNavBackground",
                 "columns": 12,
                 "styles": [
                   {
@@ -3632,7 +3632,7 @@
               },
               {
                 "name": "menuPushBackButtonColor",
-                "default": "$menuPushTopNavFontColor",
+                "default": "$menuBackButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -3660,7 +3660,7 @@
               },
               {
                 "name": "menuPushButtonColor",
-                "default": "$menuPushTopNavFontColor",
+                "default": "$menuButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -3691,7 +3691,7 @@
               },
               {
                 "name": "menuPushBackgroundColor",
-                "default": "#ffffff",
+                "default": "$menuBackgroundColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -3718,7 +3718,7 @@
               },
               {
                 "name": "menuPushFontColor",
-                "default": "$menuPushTopNavFontColor",
+                "default": "$menuFontColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -3745,7 +3745,7 @@
               },
               {
                 "name": "menuPushCloseButtonColor",
-                "default": "$menuPushTopNavFontColor",
+                "default": "$menuCloseButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -3779,7 +3779,7 @@
               },
               {
                 "name": "menuPushFooterFontColor",
-                "default": "$menuPushTopNavFontColor",
+                "default": "$menuFooterFontColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -3811,7 +3811,7 @@
             "fields": [
               {
                 "name": "menuPushTopNavBorderSides",
-                "default": "bottom",
+                "default": "$menuTopNavBorderSides",
                 "logic": {
                   "none": {
                     "hide": [
@@ -3860,7 +3860,7 @@
               },
               {
                 "name": "menuPushTopNavBorderWidth",
-                "default": "1px",
+                "default": "$menuTopNavBorderWidth",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3890,7 +3890,7 @@
               },
               {
                 "name": "menuPushTopNavBorderStyle",
-                "default": "solid",
+                "default": "$menuTopNavBorderStyle",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3919,7 +3919,7 @@
               },
               {
                 "name": "menuPushTopNavBorderColor",
-                "default": "rgba(127, 127, 127, 0.1)",
+                "default": "$menuTopNavBorderColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -3953,7 +3953,7 @@
             "fields": [
               {
                 "name": "menuPushShadowStyle",
-                "default": "none",
+                "default": "$menuShadowStyle",
                 "logic": {
                   "none": {
                     "hide": [
@@ -4014,7 +4014,7 @@
               },
               {
                 "name": "menuPushShadowXoffset",
-                "default": "0px",
+                "default": "$menuShadowXoffset",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -4048,7 +4048,7 @@
               },
               {
                 "name": "menuPushShadowYoffset",
-                "default": "0px",
+                "default": "$menuShadowYoffset",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -4082,7 +4082,7 @@
               },
               {
                 "name": "menuPushShadowBlur",
-                "default": "0px",
+                "default": "$menuShadowBlur",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -4115,7 +4115,7 @@
               },
               {
                 "name": "menuPushShadowSpread",
-                "default": "0px",
+                "default": "$menuShadowSpread",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -4148,7 +4148,7 @@
               },
               {
                 "name": "menuPushTopNavFontShadowColor",
-                "default": "rgba(51, 51, 51, 0.1)",
+                "default": "$menuTopNavFontShadowColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.push-in']",
@@ -4190,7 +4190,7 @@
             "fields": [
               {
                 "name": "menuSlideFont",
-                "default": "$bodyFontFamily",
+                "default": "$menuFont",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4215,7 +4215,7 @@
               },
               {
                 "name": "menuSlideFontSize",
-                "default": "16px",
+                "default": "$menuFontSize",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4241,7 +4241,7 @@
               },
               {
                 "name": "menuSlideTopNavFontColor",
-                "default": "$bodyTextColor",
+                "default": "$menuTopNavFontColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4270,7 +4270,7 @@
               },
               {
                 "name": "menuSlideFontWeight",
-                "default": "normal",
+                "default": "$menuFontWeight",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4296,7 +4296,7 @@
               },
               {
                 "name": "menuSlideFontStyle",
-                "default": "normal",
+                "default": "$menuFontStyle",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4322,7 +4322,7 @@
               },
               {
                 "name": "menuSlideFontDecoration",
-                "default": "none",
+                "default": "$menuFontDecoration",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4354,7 +4354,7 @@
             "fields": [
               {
                 "name": "menuSlideTopNavBackground",
-                "default": "rgba(255, 255, 255, 0.85)",
+                "default": "$menuTopNavBackground",
                 "columns": 12,
                 "styles": [
                   {
@@ -4378,7 +4378,7 @@
               },
               {
                 "name": "menuSlideBackButtonColor",
-                "default": "$menuSlideTopNavFontColor",
+                "default": "$menuBackButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -4406,7 +4406,7 @@
               },
               {
                 "name": "menuSlideButtonColor",
-                "default": "$menuSlideTopNavFontColor",
+                "default": "$menuButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -4437,7 +4437,7 @@
               },
               {
                 "name": "menuSlideBackgroundColor",
-                "default": "#ffffff",
+                "default": "$menuBackgroundColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -4464,7 +4464,7 @@
               },
               {
                 "name": "menuSlideFontColor",
-                "default": "$menuSlideTopNavFontColor",
+                "default": "$menuFontColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -4491,7 +4491,7 @@
               },
               {
                 "name": "menuSlideCloseButtonColor",
-                "default": "$menuSlideTopNavFontColor",
+                "default": "$menuCloseButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -4522,7 +4522,7 @@
               },
               {
                 "name": "menuSlideFooterFontColor",
-                "default": "$menuSlideTopNavFontColor",
+                "default": "$menuFooterFontColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -4554,7 +4554,7 @@
             "fields": [
               {
                 "name": "menuSlideTopNavBorderSides",
-                "default": "bottom",
+                "default": "$menuTopNavBorderSides",
                 "logic": {
                   "none": {
                     "hide": [
@@ -4603,7 +4603,7 @@
               },
               {
                 "name": "menuSlideTopNavBorderWidth",
-                "default": "1px",
+                "default": "$menuTopNavBorderWidth",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4633,7 +4633,7 @@
               },
               {
                 "name": "menuSlideTopNavBorderStyle",
-                "default": "solid",
+                "default": "$menuTopNavBorderStyle",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4662,7 +4662,7 @@
               },
               {
                 "name": "menuSlideTopNavBorderColor",
-                "default": "rgba(127, 127, 127, 0.1)",
+                "default": "$menuTopNavBorderColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4696,7 +4696,7 @@
             "fields": [
               {
                 "name": "menuSlideShadowStyle",
-                "default": "none",
+                "default": "$menuShadowStyle",
                 "logic": {
                   "none": {
                     "hide": [
@@ -4757,7 +4757,7 @@
               },
               {
                 "name": "menuSlideShadowXoffset",
-                "default": "0px",
+                "default": "$menuShadowXoffset",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4791,7 +4791,7 @@
               },
               {
                 "name": "menuSlideShadowYoffset",
-                "default": "0px",
+                "default": "$menuShadowYoffset",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4825,7 +4825,7 @@
               },
               {
                 "name": "menuSlideShadowBlur",
-                "default": "0px",
+                "default": "$menuShadowBlur",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4858,7 +4858,7 @@
               },
               {
                 "name": "menuSlideShadowSpread",
-                "default": "0px",
+                "default": "$menuShadowSpread",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4891,7 +4891,7 @@
               },
               {
                 "name": "menuSlideTopNavFontShadowColor",
-                "default": "rgba(51, 51, 51, 0.1)",
+                "default": "$menuTopNavFontShadowColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.slide-in']",
@@ -4933,7 +4933,7 @@
             "fields": [
               {
                 "name": "menuSwipeFont",
-                "default": "$bodyFontFamily",
+                "default": "$menuFont",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -4955,7 +4955,7 @@
               },
               {
                 "name": "menuSwipeFontSize",
-                "default": "16px",
+                "default": "$menuFontSize",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -4978,7 +4978,7 @@
               },
               {
                 "name": "menuSwipeTopNavFontColor",
-                "default": "$bodyTextColor",
+                "default": "$menuTopNavFontColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5007,7 +5007,7 @@
               },
               {
                 "name": "menuSwipeFontWeight",
-                "default": "normal",
+                "default": "$menuFontWeight",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5032,7 +5032,7 @@
               },
               {
                 "name": "menuSwipeFontStyle",
-                "default": "normal",
+                "default": "$menuFontStyle",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5057,7 +5057,7 @@
               },
               {
                 "name": "menuSwipeFontDecoration",
-                "default": "none",
+                "default": "$menuFontDecoration",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5088,7 +5088,7 @@
             "fields": [
               {
                 "name": "menuSwipeTopNavBackground",
-                "default": "rgba(255, 255, 255, 0.85)",
+                "default": "$menuTopNavBackground",
                 "columns": 12,
                 "styles": [
                   {
@@ -5115,7 +5115,7 @@
               },
               {
                 "name": "menuSwipeBackButtonColor",
-                "default": "$menuSwipeTopNavFontColor",
+                "default": "$menuBackButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -5143,7 +5143,7 @@
               },
               {
                 "name": "menuSwipeButtonColor",
-                "default": "$menuSwipeTopNavFontColor",
+                "default": "$menuButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -5174,7 +5174,7 @@
               },
               {
                 "name": "menuSwipeBackgroundColor",
-                "default": "#ffffff",
+                "default": "$menuBackgroundColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -5202,7 +5202,7 @@
               },
               {
                 "name": "menuSwipeFontColor",
-                "default": "$menuSwipeTopNavFontColor",
+                "default": "$menuTopNavFontColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -5229,7 +5229,7 @@
               },
               {
                 "name": "menuSwipeCloseButtonColor",
-                "default": "$menuSwipeTopNavFontColor",
+                "default": "$menuCloseButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -5260,7 +5260,7 @@
               },
               {
                 "name": "menuSwipeFooterFontColor",
-                "default": "$menuSwipeTopNavFontColor",
+                "default": "$menuFooterFontColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -5341,7 +5341,7 @@
               },
               {
                 "name": "menuSwipeTopNavBorderWidth",
-                "default": "1px",
+                "default": "$menuTopNavBorderWidth",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5371,7 +5371,7 @@
               },
               {
                 "name": "menuSwipeTopNavBorderStyle",
-                "default": "solid",
+                "default": "$menuTopNavBorderStyle",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5400,7 +5400,7 @@
               },
               {
                 "name": "menuSwipeTopNavBorderColor",
-                "default": "rgba(127, 127, 127, 0.1)",
+                "default": "$menuTopNavBorderColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5434,7 +5434,7 @@
             "fields": [
               {
                 "name": "menuSwipeShadowStyle",
-                "default": "none",
+                "default": "$menuShadowStyle",
                 "logic": {
                   "none": {
                     "hide": [
@@ -5495,7 +5495,7 @@
               },
               {
                 "name": "menuSwipeShadowXoffset",
-                "default": "0px",
+                "default": "$menuShadowXoffset",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5529,7 +5529,7 @@
               },
               {
                 "name": "menuSwipeShadowYoffset",
-                "default": "0px",
+                "default": "$menuShadowYoffset",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5563,7 +5563,7 @@
               },
               {
                 "name": "menuSwipeShadowBlur",
-                "default": "0px",
+                "default": "$menuShadowBlur",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5596,7 +5596,7 @@
               },
               {
                 "name": "menuSwipeShadowSpread",
-                "default": "0px",
+                "default": "$menuShadowSpread",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5629,7 +5629,7 @@
               },
               {
                 "name": "menuSwipeTopNavFontShadowColor",
-                "default": "rgba(51, 51, 51, 0.1)",
+                "default": "$menuTopNavFontShadowColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.sequential']",
@@ -5666,7 +5666,7 @@
             "fields": [
               {
                 "name": "menuSwipeWidth",
-                "default": "100%",
+                "default": "$menuWidth",
                 "columns": 12,
                 "styles": [
                   {
@@ -5702,7 +5702,7 @@
             "fields": [
               {
                 "name": "menuExpFont",
-                "default": "$bodyFontFamily",
+                "default": "$menuFont",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.expandable']",
@@ -5724,7 +5724,7 @@
               },
               {
                 "name": "menuExpFontSize",
-                "default": "16px",
+                "default": "$menuFontSize",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.expandable']",
@@ -5769,7 +5769,7 @@
               },
               {
                 "name": "menuExpFontWeight",
-                "default": "normal",
+                "default": "$menuFontWeight",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.expandable']",
@@ -5792,7 +5792,7 @@
               },
               {
                 "name": "menuExpFontStyle",
-                "default": "normal",
+                "default": "$menuFontStyle",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.expandable']",
@@ -5815,7 +5815,7 @@
               },
               {
                 "name": "menuExpFontDecoration",
-                "default": "none",
+                "default": "$menuFontDecoration",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.expandable']",
@@ -6251,7 +6251,7 @@
             "fields": [
               {
                 "name": "menuBottomFont",
-                "default": "$bodyFontFamily",
+                "default": "$menuFont",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.menu.bottom-bar']",


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4670

To fix the menus styles. This PR makes the Push In, Slide In, and Swipe menus to inherit styles from the Overlay menu.
Before we didn't have those menu types separated and now we have, but to keep styles configured by the user on v1 theme this change needs to happen.