### PR TITLE
Small tweak for Intro Layouts

### DIFF
--- a/scss/components/intro-layout.scss
+++ b/scss/components/intro-layout.scss
@@ -238,6 +238,10 @@
     introOverlayPaddingLeftDesktop: $introOverlayPaddingLeftDesktop
   ), $options);
 
+  .fl-with-top-menu .fl-intro-layout {
+    height: calc(100vh - 44px);
+  }
+
   .fl-intro-layout {
     position: relative;
     height: 100vh;


### PR DESCRIPTION
Intro Layout was updated to contain the class `.fl-intro-layout` so that we can target its elements with the new Appearance Settings, however it was missing this small change to take into account top bar menus which adds `44px` of `padding-top` to `body`.