### PR TITLE
Fixes date and time fields padding

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -588,6 +588,14 @@
       }
     }
 
+    .input-group {
+      .form-control {
+        border-top-left-radius: map-get($configuration, formInputBorderRadius);
+        border-bottom-left-radius: map-get($configuration, formInputBorderRadius);
+        padding-left: calc(45px + #{map-get($configuration, formInputPaddingLeft)});
+      }
+    }
+
     .input-group-addon {
       color: $bodyTextColor;
 

--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -252,6 +252,14 @@
           }
         }
       }
+
+      .input-group {
+        .form-control {
+          border-top-left-radius: map-get($configuration, formInputBorderRadius);
+          border-bottom-left-radius: map-get($configuration, formInputBorderRadius);
+          padding-left: calc(45px + #{map-get($configuration, formInputPaddingLeft)});
+        }
+      }
     }
 
     .form-control {
@@ -585,14 +593,6 @@
       // Styles for desktop
       @include above($desktopBreakpoint) {
         color: map-get($configuration, formRequiredColorDesktop);
-      }
-    }
-
-    .input-group {
-      .form-control {
-        border-top-left-radius: map-get($configuration, formInputBorderRadius);
-        border-bottom-left-radius: map-get($configuration, formInputBorderRadius);
-        padding-left: calc(45px + #{map-get($configuration, formInputPaddingLeft)});
       }
     }
 

--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -258,6 +258,20 @@
           border-top-left-radius: map-get($configuration, formInputBorderRadius);
           border-bottom-left-radius: map-get($configuration, formInputBorderRadius);
           padding-left: calc(45px + #{map-get($configuration, formInputPaddingLeft)});
+
+          // Styles for tablet
+          @include above($tabletBreakpoint) {
+            border-top-left-radius: map-get($configuration, formInputBorderRadiusTablet);
+            border-bottom-left-radius: map-get($configuration, formInputBorderRadiusTablet);
+            padding-left: calc(45px + #{map-get($configuration, formInputPaddingLeftTablet)});
+          }
+
+          // Styles for desktop
+          @include above($desktopBreakpoint) {
+            border-top-left-radius: map-get($configuration, formInputBorderRadiusDesktop);
+            border-bottom-left-radius: map-get($configuration, formInputBorderRadiusDesktop);
+            padding-left: calc(45px + #{map-get($configuration, formInputPaddingLeftDesktop)});
+          }
         }
       }
     }


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4723

- Added support for time and date fields

<img width="408" alt="Screenshot 2019-08-07 at 10 06 19" src="https://user-images.githubusercontent.com/7046481/62610216-1f1ff180-b8fb-11e9-8dc3-5f629f5510a7.png">
<img width="316" alt="Screenshot 2019-08-07 at 10 11 38" src="https://user-images.githubusercontent.com/7046481/62610533-c735ba80-b8fb-11e9-9451-8cdc2cd69954.png">

