### PR TITLE
Prevent padding-left on Date and Time fields to change in real time

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -15727,7 +15727,7 @@
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
-                      ".form-control",
+                      "div:not(.input-group) > .form-control",
                       ".select-proxy-display"
                     ],
                     "properties": ["padding-left"]


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4723

- Prevent `padding-left` on Date and Time fields to change in real time
  - This is because the `padding-left` property for these fields need an extra `45px` to be added and we do not have a system to do that in real time.