### PR TITLE
Force buttons to be full width on mobile

### DIFF
--- a/scss/components/buttons.scss
+++ b/scss/components/buttons.scss
@@ -8,6 +8,17 @@
 
 /* 01 - BUTTONS */
 
+.mode-interact .fl-widget-instance[data-widget-package="com.fliplet.primary-button"],
+.mode-interact .fl-widget-instance[data-widget-package="com.fliplet.secondary-button"] {
+  width: 100%;
+  
+  @media (min-width:640px) {
+    width: auto;
+  }
+}
+
+
+
 .btn-primary {
   background-color: $primaryButtonColor;
   color: $primaryButtonTextColor;


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4787
  
  
Before the new version of the theme was created, the `interact.css` would control the `width` of inline components to be `100%` on mobile, but because now the user can control those properties we had to remove them from `interact.css`.

This fix makes the buttons `width: 100%` on mobile. This is only for Theme v1.