### PR TITLE
Revamp inline link

### DIFF
--- a/scss/components/body.scss
+++ b/scss/components/body.scss
@@ -7,7 +7,6 @@
     fontSize: $bodyFontSize,
     fontWeight: $bodyFontWeight,
     fontStyle: $bodyFontStyle,
-    fontDecoration: $bodyFontDecoration,
     fontLineHeight: $bodyLineHeight
   ), $options);
 
@@ -18,7 +17,6 @@
   font-style: map-get($configuration, fontStyle);
   line-height: map-get($configuration, fontLineHeight);
   font-weight: map-get($configuration, fontWeight);
-  text-decoration: map-get($configuration, fontDecoration);
 }
 
 body {

--- a/scss/components/links.scss
+++ b/scss/components/links.scss
@@ -1,5 +1,35 @@
 @mixin inlineLink($options: (), $widgetInstanceId: '', $widgetInstanceUUID: '') {
   $configuration: map-merge((
+    linkFontFamily: $linkFontFamily,
+    linkFontFamilyHover: $linkFontFamilyHover,
+    linkFontFamilyTablet: $linkFontFamilyTablet,
+    linkFontFamilyHoverTablet: $linkFontFamilyHoverTablet,
+    linkFontFamilyDesktop: $linkFontFamilyDesktop,
+    linkFontFamilyHoverDesktop: $linkFontFamilyHoverDesktop,
+    linkFontSize: $linkFontSize,
+    linkFontSizeHover: $linkFontSizeHover,
+    linkFontSizeTablet: $linkFontSizeTablet,
+    linkFontSizeHoverTablet: $linkFontSizeHoverTablet,
+    linkFontSizeDesktop: $linkFontSizeDesktop,
+    linkFontSizeHoverDesktop: $linkFontSizeHoverDesktop,
+    linkFontWeight: $linkFontWeight,
+    linkFontWeightHover: $linkFontWeightHover,
+    linkFontWeightTablet: $linkFontWeightTablet,
+    linkFontWeightHoverTablet: $linkFontWeightHoverTablet,
+    linkFontWeightDesktop: $linkFontWeightDesktop,
+    linkFontWeightHoverDesktop: $linkFontWeightHoverDesktop,
+    linkFontStyle: $linkFontStyle,
+    linkFontStyleHover: $linkFontStyleHover,
+    linkFontStyleTablet: $linkFontStyleTablet,
+    linkFontStyleHoverTablet: $linkFontStyleHoverTablet,
+    linkFontStyleDesktop: $linkFontStyleDesktop,
+    linkFontStyleHoverDesktop: $linkFontStyleHoverDesktop,
+    linkFontDecoration: $linkFontDecoration,
+    linkFontDecorationHover: $linkFontDecorationHover,
+    linkFontDecorationTablet: $linkFontDecorationTablet,
+    linkFontDecorationHoverTablet: $linkFontDecorationHoverTablet,
+    linkFontDecorationDesktop: $linkFontDecorationDesktop,
+    linkFontDecorationHoverDesktop: $linkFontDecorationHoverDesktop,
     linkColor: $linkColor,
     linkHoverColor: $linkHoverColor,
     linkColorTablet: $linkColorTablet,
@@ -17,16 +47,30 @@
 
   #{$instanceSelector} {
     a {
-      text-decoration: none;
+      font-family: map-get($configuration, linkFontFamily);
+      font-size: map-get($configuration, linkFontSize);
+      font-weight: map-get($configuration, linkFontWeight);
+      font-style: map-get($configuration, linkFontStyle);
+      text-decoration: map-get($configuration, linkFontDecoration);
       color: map-get($configuration, linkColor);
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyTablet);
+        font-size: map-get($configuration, linkFontSizeTablet);
+        font-weight: map-get($configuration, linkFontWeightTablet);
+        font-style: map-get($configuration, linkFontStyleTablet);
+        text-decoration: map-get($configuration, linkFontDecorationTablet);
         color: map-get($configuration, linkColorTablet);
       }
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyDesktop);
+        font-size: map-get($configuration, linkFontSizeDesktop);
+        font-weight: map-get($configuration, linkFontWeightDesktop);
+        font-style: map-get($configuration, linkFontStyleDesktop);
+        text-decoration: map-get($configuration, linkFontDecorationDesktop);
         color: map-get($configuration, linkColorDesktop);
       }
 
@@ -34,34 +78,61 @@
       &:focus,
       &:active:hover,
       &:active:focus {
-        color: map-get($configuration, linkHoverColor);
-        text-decoration: none;
         outline: none;
-
+        font-family: map-get($configuration, linkFontFamilyHover);
+        font-size: map-get($configuration, linkFontSizeHover);
+        font-weight: map-get($configuration, linkFontWeightHover);
+        font-style: map-get($configuration, linkFontStyleHover);
+        text-decoration: map-get($configuration, linkFontDecorationHover);
+        color: map-get($configuration, linkHoverColor);
+  
         // Styles for tablet
         @include above($tabletBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverTablet);
+          font-size: map-get($configuration, linkFontSizeHoverTablet);
+          font-weight: map-get($configuration, linkFontWeightHoverTablet);
+          font-style: map-get($configuration, linkFontStyleHoverTablet);
+          text-decoration: map-get($configuration, linkFontDecorationHoverTablet);
           color: map-get($configuration, linkHoverColorTablet);
         }
-
+  
         // Styles for desktop
         @include above($desktopBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverDesktop);
+          font-size: map-get($configuration, linkFontSizeHoverDesktop);
+          font-weight: map-get($configuration, linkFontWeightHoverDesktop);
+          font-style: map-get($configuration, linkFontStyleHoverDesktop);
+          text-decoration: map-get($configuration, linkFontDecorationHoverDesktop);
           color: map-get($configuration, linkHoverColorDesktop);
         }
       }
     }
 
     .btn.btn-link {
-      text-decoration: none;
-
+      font-family: map-get($configuration, linkFontFamily);
+      font-size: map-get($configuration, linkFontSize);
+      font-weight: map-get($configuration, linkFontWeight);
+      font-style: map-get($configuration, linkFontStyle);
+      text-decoration: map-get($configuration, linkFontDecoration);
       color: map-get($configuration, linkColor);
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyTablet);
+        font-size: map-get($configuration, linkFontSizeTablet);
+        font-weight: map-get($configuration, linkFontWeightTablet);
+        font-style: map-get($configuration, linkFontStyleTablet);
+        text-decoration: map-get($configuration, linkFontDecorationTablet);
         color: map-get($configuration, linkColorTablet);
       }
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyDesktop);
+        font-size: map-get($configuration, linkFontSizeDesktop);
+        font-weight: map-get($configuration, linkFontWeightDesktop);
+        font-style: map-get($configuration, linkFontStyleDesktop);
+        text-decoration: map-get($configuration, linkFontDecorationDesktop);
         color: map-get($configuration, linkColorDesktop);
       }
 
@@ -69,17 +140,31 @@
       &:focus,
       &:active:hover,
       &:active:focus {
-        color: map-get($configuration, linkHoverColor);
-        text-decoration: none;
         outline: none;
-
+        font-family: map-get($configuration, linkFontFamilyHover);
+        font-size: map-get($configuration, linkFontSizeHover);
+        font-weight: map-get($configuration, linkFontWeightHover);
+        font-style: map-get($configuration, linkFontStyleHover);
+        text-decoration: map-get($configuration, linkFontDecorationHover);
+        color: map-get($configuration, linkHoverColor);
+  
         // Styles for tablet
         @include above($tabletBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverTablet);
+          font-size: map-get($configuration, linkFontSizeHoverTablet);
+          font-weight: map-get($configuration, linkFontWeightHoverTablet);
+          font-style: map-get($configuration, linkFontStyleHoverTablet);
+          text-decoration: map-get($configuration, linkFontDecorationHoverTablet);
           color: map-get($configuration, linkHoverColorTablet);
         }
-
+  
         // Styles for desktop
         @include above($desktopBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverDesktop);
+          font-size: map-get($configuration, linkFontSizeHoverDesktop);
+          font-weight: map-get($configuration, linkFontWeightHoverDesktop);
+          font-style: map-get($configuration, linkFontStyleHoverDesktop);
+          text-decoration: map-get($configuration, linkFontDecorationHoverDesktop);
           color: map-get($configuration, linkHoverColorDesktop);
         }
       }

--- a/scss/components/text.scss
+++ b/scss/components/text.scss
@@ -39,13 +39,13 @@
     textShadowBlur: $textShadowBlur,
     textShadowSpread: $textShadowSpread,
     textShadowColor: $textShadowColor,
-    bodyFontFamily: $bodyFontFamily,
-    bodyFontSize: $bodyFontSize,
-    bodyTextColor: $bodyTextColor,
-    bodyFontWeight: $bodyFontWeight,
-    bodyFontStyle: $bodyFontStyle,
-    bodyFontDecoration: $bodyFontDecoration,
-    bodyLineHeight: $bodyLineHeight,
+    paragraphFontFamily: $paragraphFontFamily,
+    paragraphFontSize: $paragraphFontSize,
+    paragraphTextColor: $paragraphTextColor,
+    paragraphFontWeight: $paragraphFontWeight,
+    paragraphFontStyle: $paragraphFontStyle,
+    paragraphFontDecoration: $paragraphFontDecoration,
+    paragraphLineHeight: $paragraphLineHeight,
     paragraphMarginTop: $paragraphMarginTop,
     paragraphMarginBottom: $paragraphMarginBottom,
     textVisibility: $textVisibility,
@@ -88,13 +88,13 @@
     textShadowBlurTablet: $textShadowBlurTablet,
     textShadowSpreadTablet: $textShadowSpreadTablet,
     textShadowColorTablet: $textShadowColorTablet,
-    bodyFontFamilyTablet: $bodyFontFamilyTablet,
-    bodyFontSizeTablet: $bodyFontSizeTablet,
-    bodyTextColorTablet: $bodyTextColorTablet,
-    bodyFontWeightTablet: $bodyFontWeightTablet,
-    bodyFontStyleTablet: $bodyFontStyleTablet,
-    bodyFontDecorationTablet: $bodyFontDecorationTablet,
-    bodyLineHeightTablet: $bodyLineHeightTablet,
+    paragraphFontFamilyTablet: $paragraphFontFamilyTablet,
+    paragraphFontSizeTablet: $paragraphFontSizeTablet,
+    paragraphTextColorTablet: $paragraphTextColorTablet,
+    paragraphFontWeightTablet: $paragraphFontWeightTablet,
+    paragraphFontStyleTablet: $paragraphFontStyleTablet,
+    paragraphFontDecorationTablet: $paragraphFontDecorationTablet,
+    paragraphLineHeightTablet: $paragraphLineHeightTablet,
     paragraphMarginTopTablet: $paragraphMarginTopTablet,
     paragraphMarginBottomTablet: $paragraphMarginBottomTablet,
     textVisibilityTablet: $textVisibilityTablet,
@@ -137,13 +137,13 @@
     textShadowBlurDesktop: $textShadowBlurDesktop,
     textShadowSpreadDesktop: $textShadowSpreadDesktop,
     textShadowColorDesktop: $textShadowColorDesktop,
-    bodyFontFamilyDesktop: $bodyFontFamilyDesktop,
-    bodyFontSizeDesktop: $bodyFontSizeDesktop,
-    bodyTextColorDesktop: $bodyTextColorDesktop,
-    bodyFontWeightDesktop: $bodyFontWeightDesktop,
-    bodyFontStyleDesktop: $bodyFontStyleDesktop,
-    bodyFontDecorationDesktop: $bodyFontDecorationDesktop,
-    bodyLineHeightDesktop: $bodyLineHeightDesktop,
+    paragraphFontFamilyDesktop: $paragraphFontFamilyDesktop,
+    paragraphFontSizeDesktop: $paragraphFontSizeDesktop,
+    paragraphTextColorDesktop: $paragraphTextColorDesktop,
+    paragraphFontWeightDesktop: $paragraphFontWeightDesktop,
+    paragraphFontStyleDesktop: $paragraphFontStyleDesktop,
+    paragraphFontDecorationDesktop: $paragraphFontDecorationDesktop,
+    paragraphLineHeightDesktop: $paragraphLineHeightDesktop,
     paragraphMarginTopDesktop: $paragraphMarginTopDesktop,
     paragraphMarginBottomDesktop: $paragraphMarginBottomDesktop,
     textVisibilityDesktop: $textVisibilityDesktop,
@@ -539,13 +539,13 @@
     }
 
     p {
-      color: map-get($configuration, bodyTextColor);
-      font-family: map-get($configuration, bodyFontFamily);
-      font-size: map-get($configuration, bodyFontSize);
-      font-style: map-get($configuration, bodyFontStyle);
-      text-decoration: map-get($configuration, bodyFontDecoration);
-      line-height: map-get($configuration, bodyLineHeight);
-      font-weight: map-get($configuration, bodyFontWeight);
+      color: map-get($configuration, paragraphTextColor);
+      font-family: map-get($configuration, paragraphFontFamily);
+      font-size: map-get($configuration, paragraphFontSize);
+      font-style: map-get($configuration, paragraphFontStyle);
+      text-decoration: map-get($configuration, paragraphFontDecoration);
+      line-height: map-get($configuration, paragraphLineHeight);
+      font-weight: map-get($configuration, paragraphFontWeight);
       min-height: 1em;
 
       margin-top: map-get($configuration, paragraphMarginTop);
@@ -553,13 +553,13 @@
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
-        color: map-get($configuration, bodyTextColorTablet);
-        font-family: map-get($configuration, bodyFontFamilyTablet);
-        font-size: map-get($configuration, bodyFontSizeTablet);
-        font-style: map-get($configuration, bodyFontStyleTablet);
-        text-decoration: map-get($configuration, bodyFontDecorationTablet);
-        line-height: map-get($configuration, bodyLineHeightTablet);
-        font-weight: map-get($configuration, bodyFontWeightTablet);
+        color: map-get($configuration, paragraphTextColorTablet);
+        font-family: map-get($configuration, paragraphFontFamilyTablet);
+        font-size: map-get($configuration, paragraphFontSizeTablet);
+        font-style: map-get($configuration, paragraphFontStyleTablet);
+        text-decoration: map-get($configuration, paragraphFontDecorationTablet);
+        line-height: map-get($configuration, paragraphLineHeightTablet);
+        font-weight: map-get($configuration, paragraphFontWeightTablet);
 
         margin-top: map-get($configuration, paragraphMarginTopTablet);
         margin-bottom: map-get($configuration, paragraphMarginBottomTablet);
@@ -567,13 +567,13 @@
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
-        color: map-get($configuration, bodyTextColorDesktop);
-        font-family: map-get($configuration, bodyFontFamilyDesktop);
-        font-size: map-get($configuration, bodyFontSizeDesktop);
-        font-style: map-get($configuration, bodyFontStyleDesktop);
-        text-decoration: map-get($configuration, bodyFontDecorationDesktop);
-        line-height: map-get($configuration, bodyLineHeightDesktop);
-        font-weight: map-get($configuration, bodyFontWeightDesktop);
+        color: map-get($configuration, paragraphTextColorDesktop);
+        font-family: map-get($configuration, paragraphFontFamilyDesktop);
+        font-size: map-get($configuration, paragraphFontSizeDesktop);
+        font-style: map-get($configuration, paragraphFontStyleDesktop);
+        text-decoration: map-get($configuration, paragraphFontDecorationDesktop);
+        line-height: map-get($configuration, paragraphLineHeightDesktop);
+        font-weight: map-get($configuration, paragraphFontWeightDesktop);
 
         margin-top: map-get($configuration, paragraphMarginTopDesktop);
         margin-bottom: map-get($configuration, paragraphMarginBottomDesktop);

--- a/theme.json
+++ b/theme.json
@@ -14563,22 +14563,57 @@
         "packages": ["com.fliplet.inline-link"],
         "variables": [
           {
-            "description": "Colors",
+            "description": "Text",
             "fields": [
+              {
+                "name": "linkFontFamily",
+                "default": "$paragraphFontFamily",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-family"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontFamilyTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontFamilyDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font"
+              },
+              {
+                "name": "linkFontSize",
+                "default": "$paragraphFontSize",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-size"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontSizeTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontSizeDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subtype": "font"
+              },
               {
                 "name": "linkColor",
                 "default": "$highlightColor",
-                "columns": 12,
                 "styles": [
-                  {
-                    "selectors": [
-                      ".overlay-about-app .btn-link",
-                      ".overlay-update-notes .btn-link",
-                      ".overlay-about-app a",
-                      ".overlay-update-notes a"
-                    ],
-                    "properties": ["color"]
-                  },
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
                     "selectors": [
@@ -14586,11 +14621,6 @@
                       ".btn.btn-link"
                     ],
                     "properties": ["color"]
-                  },
-                  {
-                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".fl-form .spinner-overlay",
-                    "properties": ["border-left-color"]
                   }
                 ],
                 "breakpoints": {
@@ -14603,13 +14633,121 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Color",
                 "type": "color"
+              },
+              {
+                "name": "linkFontWeight",
+                "default": "$paragraphFontWeight",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-weight"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontWeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontWeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "weight"
+              },
+              {
+                "name": "linkFontStyle",
+                "default": "$paragraphFontStyle",
+                "styles": [
+                  {
+                    "selectors": "body",
+                    "properties": ["font-style"]
+                  },
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-style"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontStyleTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontStyleDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "italic"
+              },
+              {
+                "name": "linkFontDecoration",
+                "default": "$paragraphFontDecoration",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["text-decoration"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontDecorationTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontDecorationDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "subType": "decoration",
+                "properties": "underline"
+              }
+            ]
+          },
+          {
+            "description": "Text Hover",
+            "fields": [
+              {
+                "name": "linkFontFamilyHover",
+                "default": "$linkFontFamily",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontFamilyHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontFamilyHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font"
+              },
+              {
+                "name": "linkFontSizeHover",
+                "default": "$linkFontSize",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontSizeHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontSizeHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subtype": "font"
               },
               {
                 "name": "linkHoverColor",
                 "default": "#0096B8",
-                "columns": 12,
                 "breakpoints": {
                   "tablet": {
                     "name": "linkHoverColorTablet",
@@ -14620,8 +14758,56 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Color when clicked",
                 "type": "color"
+              },
+              {
+                "name": "linkFontWeightHover",
+                "default": "$linkFontWeight",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontWeightHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontWeightHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "weight"
+              },
+              {
+                "name": "linkFontStyleHover",
+                "default": "$linkFontStyle",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontStyleHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontStyleHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "italic"
+              },
+              {
+                "name": "linkFontDecorationHover",
+                "default": "$linkFontDecoration",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontDecorationHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontDecorationHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "subType": "decoration",
+                "properties": "underline"
               }
             ]
           }

--- a/theme.json
+++ b/theme.json
@@ -484,7 +484,7 @@
               },
               {
                 "name": "headingOneWeight",
-                "default": "normal",
+                "default": "bold",
                 "styles": [
                   {
                     "selectors": "h1",
@@ -700,7 +700,7 @@
               },
               {
                 "name": "headingTwoWeight",
-                "default": "normal",
+                "default": "bold",
                 "styles": [
                   {
                     "selectors": "h2",
@@ -910,7 +910,7 @@
               },
               {
                 "name": "headingThreeWeight",
-                "default": "normal",
+                "default": "bold",
                 "styles": [
                   {
                     "selectors": "h3",
@@ -2104,7 +2104,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "textDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "textDisplayDesktop",
@@ -2911,7 +2911,7 @@
             "description": "Paragraph",
             "fields": [
               {
-                "name": "bodyFontFamily",
+                "name": "paragraphFontFamily",
                 "default": "$quickTextFontFamily",
                 "styles": [
                   {
@@ -2926,18 +2926,18 @@
                 ],
                 "breakpoints": {
                   "tablet": {
-                    "name": "bodyFontFamilyTablet",
+                    "name": "paragraphFontFamilyTablet",
                     "default": "inherit-mobile"
                   },
                   "desktop": {
-                    "name": "bodyFontFamilyDesktop",
+                    "name": "paragraphFontFamilyDesktop",
                     "default": "inherit-tablet"
                   }
                 },
                 "type": "font"
               },
               {
-                "name": "bodyFontSize",
+                "name": "paragraphFontSize",
                 "default": "$bodyFontSize",
                 "styles": [
                   {
@@ -2952,11 +2952,11 @@
                 ],
                 "breakpoints": {
                   "tablet": {
-                    "name": "bodyFontSizeTablet",
+                    "name": "paragraphFontSizeTablet",
                     "default": "inherit-mobile"
                   },
                   "desktop": {
-                    "name": "bodyFontSizeDesktop",
+                    "name": "paragraphFontSizeDesktop",
                     "default": "inherit-tablet"
                   }
                 },
@@ -2964,7 +2964,7 @@
                 "subtype": "font"
               },
               {
-                "name": "bodyTextColor",
+                "name": "paragraphTextColor",
                 "default": "$bodyTextColor",
                 "styles": [
                   {
@@ -3054,18 +3054,18 @@
                 ],
                 "breakpoints": {
                   "tablet": {
-                    "name": "bodyTextColorTablet",
+                    "name": "paragraphTextColorTablet",
                     "default": "inherit-mobile"
                   },
                   "desktop": {
-                    "name": "bodyTextColorDesktop",
+                    "name": "paragraphTextColorDesktop",
                     "default": "inherit-tablet"
                   }
                 },
                 "type": "color"
               },
               {
-                "name": "bodyFontWeight",
+                "name": "paragraphFontWeight",
                 "default": "$bodyFontWeight",
                 "styles": [
                   {
@@ -3080,11 +3080,11 @@
                 ],
                 "breakpoints": {
                   "tablet": {
-                    "name": "bodyFontWeightTablet",
+                    "name": "paragraphFontWeightTablet",
                     "default": "inherit-mobile"
                   },
                   "desktop": {
-                    "name": "bodyFontWeightDesktop",
+                    "name": "paragraphFontWeightDesktop",
                     "default": "inherit-tablet"
                   }
                 },
@@ -3092,7 +3092,7 @@
                 "properties": "weight"
               },
               {
-                "name": "bodyFontStyle",
+                "name": "paragraphFontStyle",
                 "default": "$bodyFontStyle",
                 "styles": [
                   {
@@ -3107,11 +3107,11 @@
                 ],
                 "breakpoints": {
                   "tablet": {
-                    "name": "bodyFontStyleTablet",
+                    "name": "paragraphFontStyleTablet",
                     "default": "inherit-mobile"
                   },
                   "desktop": {
-                    "name": "bodyFontStyleDesktop",
+                    "name": "paragraphFontStyleDesktop",
                     "default": "inherit-tablet"
                   }
                 },
@@ -3119,7 +3119,7 @@
                 "properties": "italic"
               },
               {
-                "name": "bodyFontDecoration",
+                "name": "paragraphFontDecoration",
                 "default": "none",
                 "styles": [
                   {
@@ -3130,11 +3130,11 @@
                 ],
                 "breakpoints": {
                   "tablet": {
-                    "name": "bodyFontDecorationTablet",
+                    "name": "paragraphFontDecorationTablet",
                     "default": "inherit-mobile"
                   },
                   "desktop": {
-                    "name": "bodyFontDecorationDesktop",
+                    "name": "paragraphFontDecorationDesktop",
                     "default": "inherit-tablet"
                   }
                 },
@@ -3143,7 +3143,7 @@
                 "properties": "underline"
               },
               {
-                "name": "bodyLineHeight",
+                "name": "paragraphLineHeight",
                 "default": "$bodyLineHeight",
                 "styles": [
                   {
@@ -3158,11 +3158,11 @@
                 ],
                 "breakpoints": {
                   "tablet": {
-                    "name": "bodyLineHeightTablet",
+                    "name": "paragraphLineHeightTablet",
                     "default": "inherit-mobile"
                   },
                   "desktop": {
-                    "name": "bodyLineHeightDesktop",
+                    "name": "paragraphLineHeightDesktop",
                     "default": "inherit-tablet"
                   }
                 },
@@ -4761,7 +4761,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "containerWidthTablet",
-                    "default": "auto"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "containerWidthDesktop",

--- a/theme.json
+++ b/theme.json
@@ -19401,7 +19401,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "formDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "formDisplayDesktop",
@@ -23838,7 +23838,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "listDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "listDisplayDesktop",
@@ -25110,7 +25110,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "listSmallDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "listSmallDisplayDesktop",
@@ -26447,7 +26447,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "listLargeDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "listLargeDisplayDesktop",
@@ -27761,7 +27761,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "lfdDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "lfdDisplayDesktop",
@@ -28825,7 +28825,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "lockDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "lockDisplayDesktop",
@@ -31945,7 +31945,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "panelDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "panelDisplayDesktop",
@@ -33984,7 +33984,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "rssDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "rssDisplayDesktop",

--- a/theme.json
+++ b/theme.json
@@ -3413,7 +3413,7 @@
               },
               {
                 "name": "textHeadingOneMarginBottom",
-                "default": "$headingOneMarginBottom",
+                "default": "10px",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.text']",
@@ -3629,7 +3629,7 @@
               },
               {
                 "name": "textHeadingTwoMarginBottom",
-                "default": "$headingTwoMarginBottom",
+                "default": "10px",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.text']",
@@ -3848,7 +3848,7 @@
               },
               {
                 "name": "textHeadingThreeMarginBottom",
-                "default": "$headingThreeMarginBottom",
+                "default": "10px",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.text']",
@@ -4064,7 +4064,7 @@
               },
               {
                 "name": "textHeadingFourMarginBottom",
-                "default": "$headingFourMarginBottom",
+                "default": "10px",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.text']",
@@ -4280,7 +4280,7 @@
               },
               {
                 "name": "textHeadingFiveMarginBottom",
-                "default": "$headingFiveMarginBottom",
+                "default": "10px",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.text']",
@@ -4496,7 +4496,7 @@
               },
               {
                 "name": "textHeadingSixMarginBottom",
-                "default": "$headingSixMarginBottom",
+                "default": "10px",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.text']",


### PR DESCRIPTION
By fixing the following issue, https://github.com/Fliplet/fliplet-studio/issues/5510, I have noticed that it was impossible to set normal font styles to links, on both old and new drag and drop systems.

This change addresses that problem.