### PR TITLE
Added more options for inline links

### DIFF
--- a/scss/components/links.scss
+++ b/scss/components/links.scss
@@ -1,5 +1,35 @@
 @mixin inlineLink($options: (), $widgetInstanceId: '', $widgetInstanceUUID: '') {
   $configuration: map-merge((
+    linkFontFamily: $linkFontFamily,
+    linkFontFamilyHover: $linkFontFamilyHover,
+    linkFontFamilyTablet: $linkFontFamilyTablet,
+    linkFontFamilyHoverTablet: $linkFontFamilyHoverTablet,
+    linkFontFamilyDesktop: $linkFontFamilyDesktop,
+    linkFontFamilyHoverDesktop: $linkFontFamilyHoverDesktop,
+    linkFontSize: $linkFontSize,
+    linkFontSizeHover: $linkFontSizeHover,
+    linkFontSizeTablet: $linkFontSizeTablet,
+    linkFontSizeHoverTablet: $linkFontSizeHoverTablet,
+    linkFontSizeDesktop: $linkFontSizeDesktop,
+    linkFontSizeHoverDesktop: $linkFontSizeHoverDesktop,
+    linkFontWeight: $linkFontWeight,
+    linkFontWeightHover: $linkFontWeightHover,
+    linkFontWeightTablet: $linkFontWeightTablet,
+    linkFontWeightHoverTablet: $linkFontWeightHoverTablet,
+    linkFontWeightDesktop: $linkFontWeightDesktop,
+    linkFontWeightHoverDesktop: $linkFontWeightHoverDesktop,
+    linkFontStyle: $linkFontStyle,
+    linkFontStyleHover: $linkFontStyleHover,
+    linkFontStyleTablet: $linkFontStyleTablet,
+    linkFontStyleHoverTablet: $linkFontStyleHoverTablet,
+    linkFontStyleDesktop: $linkFontStyleDesktop,
+    linkFontStyleHoverDesktop: $linkFontStyleHoverDesktop,
+    linkFontDecoration: $linkFontDecoration,
+    linkFontDecorationHover: $linkFontDecorationHover,
+    linkFontDecorationTablet: $linkFontDecorationTablet,
+    linkFontDecorationHoverTablet: $linkFontDecorationHoverTablet,
+    linkFontDecorationDesktop: $linkFontDecorationDesktop,
+    linkFontDecorationHoverDesktop: $linkFontDecorationHoverDesktop,
     linkColor: $linkColor,
     linkHoverColor: $linkHoverColor,
     linkColorTablet: $linkColorTablet,
@@ -17,16 +47,30 @@
 
   #{$instanceSelector} {
     a {
-      text-decoration: none;
+      font-family: map-get($configuration, linkFontFamily);
+      font-size: map-get($configuration, linkFontSize);
+      font-weight: map-get($configuration, linkFontWeight);
+      font-style: map-get($configuration, linkFontStyle);
+      text-decoration: map-get($configuration, linkFontDecoration);
       color: map-get($configuration, linkColor);
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyTablet);
+        font-size: map-get($configuration, linkFontSizeTablet);
+        font-weight: map-get($configuration, linkFontWeightTablet);
+        font-style: map-get($configuration, linkFontStyleTablet);
+        text-decoration: map-get($configuration, linkFontDecorationTablet);
         color: map-get($configuration, linkColorTablet);
       }
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyDesktop);
+        font-size: map-get($configuration, linkFontSizeDesktop);
+        font-weight: map-get($configuration, linkFontWeightDesktop);
+        font-style: map-get($configuration, linkFontStyleDesktop);
+        text-decoration: map-get($configuration, linkFontDecorationDesktop);
         color: map-get($configuration, linkColorDesktop);
       }
 
@@ -34,34 +78,61 @@
       &:focus,
       &:active:hover,
       &:active:focus {
-        color: map-get($configuration, linkHoverColor);
-        text-decoration: none;
         outline: none;
-
+        font-family: map-get($configuration, linkFontFamilyHover);
+        font-size: map-get($configuration, linkFontSizeHover);
+        font-weight: map-get($configuration, linkFontWeightHover);
+        font-style: map-get($configuration, linkFontStyleHover);
+        text-decoration: map-get($configuration, linkFontDecorationHover);
+        color: map-get($configuration, linkHoverColor);
+  
         // Styles for tablet
         @include above($tabletBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverTablet);
+          font-size: map-get($configuration, linkFontSizeHoverTablet);
+          font-weight: map-get($configuration, linkFontWeightHoverTablet);
+          font-style: map-get($configuration, linkFontStyleHoverTablet);
+          text-decoration: map-get($configuration, linkFontDecorationHoverTablet);
           color: map-get($configuration, linkHoverColorTablet);
         }
-
+  
         // Styles for desktop
         @include above($desktopBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverDesktop);
+          font-size: map-get($configuration, linkFontSizeHoverDesktop);
+          font-weight: map-get($configuration, linkFontWeightHoverDesktop);
+          font-style: map-get($configuration, linkFontStyleHoverDesktop);
+          text-decoration: map-get($configuration, linkFontDecorationHoverDesktop);
           color: map-get($configuration, linkHoverColorDesktop);
         }
       }
     }
 
     .btn.btn-link {
-      text-decoration: none;
-
+      font-family: map-get($configuration, linkFontFamily);
+      font-size: map-get($configuration, linkFontSize);
+      font-weight: map-get($configuration, linkFontWeight);
+      font-style: map-get($configuration, linkFontStyle);
+      text-decoration: map-get($configuration, linkFontDecoration);
       color: map-get($configuration, linkColor);
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyTablet);
+        font-size: map-get($configuration, linkFontSizeTablet);
+        font-weight: map-get($configuration, linkFontWeightTablet);
+        font-style: map-get($configuration, linkFontStyleTablet);
+        text-decoration: map-get($configuration, linkFontDecorationTablet);
         color: map-get($configuration, linkColorTablet);
       }
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
+        font-family: map-get($configuration, linkFontFamilyDesktop);
+        font-size: map-get($configuration, linkFontSizeDesktop);
+        font-weight: map-get($configuration, linkFontWeightDesktop);
+        font-style: map-get($configuration, linkFontStyleDesktop);
+        text-decoration: map-get($configuration, linkFontDecorationDesktop);
         color: map-get($configuration, linkColorDesktop);
       }
 
@@ -69,17 +140,31 @@
       &:focus,
       &:active:hover,
       &:active:focus {
-        color: map-get($configuration, linkHoverColor);
-        text-decoration: none;
         outline: none;
-
+        font-family: map-get($configuration, linkFontFamilyHover);
+        font-size: map-get($configuration, linkFontSizeHover);
+        font-weight: map-get($configuration, linkFontWeightHover);
+        font-style: map-get($configuration, linkFontStyleHover);
+        text-decoration: map-get($configuration, linkFontDecorationHover);
+        color: map-get($configuration, linkHoverColor);
+  
         // Styles for tablet
         @include above($tabletBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverTablet);
+          font-size: map-get($configuration, linkFontSizeHoverTablet);
+          font-weight: map-get($configuration, linkFontWeightHoverTablet);
+          font-style: map-get($configuration, linkFontStyleHoverTablet);
+          text-decoration: map-get($configuration, linkFontDecorationHoverTablet);
           color: map-get($configuration, linkHoverColorTablet);
         }
-
+  
         // Styles for desktop
         @include above($desktopBreakpoint) {
+          font-family: map-get($configuration, linkFontFamilyHoverDesktop);
+          font-size: map-get($configuration, linkFontSizeHoverDesktop);
+          font-weight: map-get($configuration, linkFontWeightHoverDesktop);
+          font-style: map-get($configuration, linkFontStyleHoverDesktop);
+          text-decoration: map-get($configuration, linkFontDecorationHoverDesktop);
           color: map-get($configuration, linkHoverColorDesktop);
         }
       }

--- a/theme.json
+++ b/theme.json
@@ -14563,12 +14563,56 @@
         "packages": ["com.fliplet.inline-link"],
         "variables": [
           {
-            "description": "Colors",
+            "description": "Text",
             "fields": [
+              {
+                "name": "linkFontFamily",
+                "default": "$paragraphFontFamily",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-family"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontFamilyTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontFamilyDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font"
+              },
+              {
+                "name": "linkFontSize",
+                "default": "$paragraphFontSize",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-size"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontSizeTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontSizeDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subtype": "font"
+              },
               {
                 "name": "linkColor",
                 "default": "$highlightColor",
-                "columns": 12,
                 "styles": [
                   {
                     "selectors": [
@@ -14603,13 +14647,121 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Color",
                 "type": "color"
+              },
+              {
+                "name": "linkFontWeight",
+                "default": "$paragraphFontWeight",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-weight"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontWeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontWeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "weight"
+              },
+              {
+                "name": "linkFontStyle",
+                "default": "$paragraphFontStyle",
+                "styles": [
+                  {
+                    "selectors": "body",
+                    "properties": ["font-style"]
+                  },
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["font-style"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontStyleTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontStyleDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "italic"
+              },
+              {
+                "name": "linkFontDecoration",
+                "default": "$paragraphFontDecoration",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.inline-link']",
+                    "selectors": "a",
+                    "properties": ["text-decoration"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontDecorationTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontDecorationDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "subType": "decoration",
+                "properties": "underline"
+              }
+            ]
+          },
+          {
+            "description": "Text Hover",
+            "fields": [
+              {
+                "name": "linkFontFamilyHover",
+                "default": "$linkFontFamily",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontFamilyHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontFamilyHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font"
+              },
+              {
+                "name": "linkFontSizeHover",
+                "default": "$linkFontSize",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontSizeHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontSizeHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subtype": "font"
               },
               {
                 "name": "linkHoverColor",
                 "default": "#0096B8",
-                "columns": 12,
                 "breakpoints": {
                   "tablet": {
                     "name": "linkHoverColorTablet",
@@ -14620,8 +14772,56 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Color when clicked",
                 "type": "color"
+              },
+              {
+                "name": "linkFontWeightHover",
+                "default": "$linkFontWeight",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontWeightHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontWeightHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "weight"
+              },
+              {
+                "name": "linkFontStyleHover",
+                "default": "$linkFontStyle",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontStyleHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontStyleHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "italic"
+              },
+              {
+                "name": "linkFontDecorationHover",
+                "default": "$linkFontDecoration",
+                "breakpoints": {
+                  "tablet": {
+                    "name": "linkFontDecorationHoverTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "linkFontDecorationHoverDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "subType": "decoration",
+                "properties": "underline"
               }
             ]
           }


### PR DESCRIPTION
By fixing the following issue, https://github.com/Fliplet/fliplet-studio/issues/5510, I have noticed that it was impossible to set normal font styles to links, on both old and new drag and drop systems.

This change addresses that problem.