### PR TITLE
Set min-height of containers to 20px

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -4847,7 +4847,7 @@
               },
               {
                 "name": "containerMinHeight",
-                "default": "100px",
+                "default": "20px",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.container']",


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/5647

The `min-height` was too high, creating a bad experience for some uses that wanted to add small elements inside the container component.