### PR TITLE
Onboarding text color now inherits general text color

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -31378,7 +31378,7 @@
               },
               {
                 "name": "onboardingTextColor",
-                "default": "rgba(51, 51, 51, 0.7)",
+                "default": "$bodyTextColor",
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.onboarding']",


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4734

## Description
Onboarding text color now inherits general text color which inherits quick settings color.

## Screenshots/screencasts
![onboarding-styling](https://user-images.githubusercontent.com/52824207/73741839-c4edd500-4753-11ea-9211-e605bac49b38.gif)

## Backward compatibility
This change is fully backward compatible.