### PR TITLE
Border properties now affect rich text field

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -793,7 +793,7 @@
       }
     }
 
-    .form-group .mce-tinymce,
+    .form-group .mce-tinymce > .mce-container-body.mce-stack-layout,
     .form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket {
       @include borderOnly((
         borderWidth: map-get($configuration, formInputBorderWidth),
@@ -801,6 +801,9 @@
         borderColor: map-get($configuration, formInputBorderColor),
         borderSides: map-get($configuration, formInputBorderSides)
       ));
+
+      border-radius: $formInputBorderRadius;
+      overflow: hidden;
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
@@ -902,4 +905,4 @@
   ));
 
   border-radius: $formInputBorderRadius;
-} 
+}

--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -826,35 +826,6 @@
       }
     }
 
-    .form-group .mce-top-part::before {
-      @include borderOnly((
-        borderWidth: map-get($configuration, formInputBorderWidth),
-        borderStyle: map-get($configuration, formInputBorderStyle),
-        borderColor: map-get($configuration, formInputBorderColor),
-        borderSides: 'bottom'
-      ));
-
-      // Styles for tablet
-      @include above($tabletBreakpoint) {
-        @include borderOnly((
-          borderWidth: map-get($configuration, formInputBorderWidthTablet),
-          borderStyle: map-get($configuration, formInputBorderStyleTablet),
-          borderColor: map-get($configuration, formInputBorderColorTablet),
-          borderSides: 'bottom'
-        ));
-      }
-
-      // Styles for desktop
-      @include above($desktopBreakpoint) {
-        @include borderOnly((
-          borderWidth: map-get($configuration, formInputBorderWidthDesktop),
-          borderStyle: map-get($configuration, formInputBorderStyleDesktop),
-          borderColor: map-get($configuration, formInputBorderColorDesktop),
-          borderSides: 'bottom'
-        ));
-      }
-    }
-
     .sending-form {
       color: $bodyTextColor;
 

--- a/theme.json
+++ b/theme.json
@@ -20213,7 +20213,7 @@
                       ".select-proxy-display",
                       ".select-proxy-display>.icon",
                       ".field-signature canvas",
-                      ".form-group .mce-tinymce",
+                      ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout",
                       ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket"
                     ],
                     "properties": ["border"],
@@ -20250,7 +20250,7 @@
                       ".select-proxy-display",
                       ".select-proxy-display>.icon",
                       ".field-signature canvas",
-                      ".form-group .mce-tinymce",
+                      ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout",
                       ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket"
                     ],
                     "properties": ["border"],
@@ -20286,7 +20286,7 @@
                       ".select-proxy-display",
                       ".select-proxy-display>.icon",
                       ".field-signature canvas",
-                      ".form-group .mce-tinymce",
+                      ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout",
                       ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket"
                     ],
                     "properties": ["border"],
@@ -20323,7 +20323,7 @@
                       ".select-proxy-display",
                       ".select-proxy-display>.icon",
                       ".field-signature canvas",
-                      ".form-group .mce-tinymce",
+                      ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout",
                       ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket"
                     ],
                     "properties": ["border"],


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4724

## Description
Updated selectors.

## Screenshots/screencasts
![form-rich-text](https://user-images.githubusercontent.com/52824207/73848042-05bb1c00-4830-11ea-908d-7b54c8d0a6d7.PNG)

## Backward compatibility
This change is fully backward compatible.

## Notes
Goes together with this PR https://github.com/Fliplet/fliplet-widget-form-builder/pull/270