### PR TITLE
Users now can change background for published in-app notifications

### DIFF
--- a/scss/components/notification-inbox.scss
+++ b/scss/components/notification-inbox.scss
@@ -13,6 +13,7 @@
     notificationPaddingLeft: $notificationPaddingLeft,
     notificationBadgeBackgroundColor: $notificationBadgeBackgroundColor,
     notificationDraftBackgroundColor: $notificationDraftBackgroundColor,
+    notificationPublishedBackgroundColor: $notificationPublishedBackgroundColor,
     notificationWidthTablet: $notificationWidthTablet,
     notificationMinWidthTablet: $notificationMinWidthTablet,
     notificationMaxWidthTablet: $notificationMaxWidthTablet,
@@ -26,6 +27,7 @@
     notificationPaddingLeftTablet: $notificationPaddingLeftTablet,
     notificationBadgeBackgroundColorTablet: $notificationBadgeBackgroundColorTablet,
     notificationDraftBackgroundColorTablet: $notificationDraftBackgroundColorTablet,
+    notificationPublishedBackgroundColorTablet: $notificationPublishedBackgroundColorTablet,
     notificationWidthDesktop: $notificationWidthDesktop,
     notificationMinWidthDesktop: $notificationMinWidthDesktop,
     notificationMaxWidthDesktop: $notificationMaxWidthDesktop,
@@ -39,6 +41,7 @@
     notificationPaddingLeftDesktop: $notificationPaddingLeftDesktop,
     notificationBadgeBackgroundColorDesktop: $notificationBadgeBackgroundColorDesktop,
     notificationDraftBackgroundColorDesktop: $notificationDraftBackgroundColorDesktop,
+    notificationPublishedBackgroundColorDesktop: $notificationPublishedBackgroundColorDesktop
   ), $options);
 
   $instanceSelector: '[data-widget-package="com.fliplet.notificationinbox"]';
@@ -109,6 +112,10 @@
         background-color: map-get($configuration, notificationDraftBackgroundColor);
       }
 
+      .notification[data-notification-status="published"] {
+        background-color: map-get($configuration, notificationPublishedBackgroundColor);
+      }
+
       // Styles for tablet
       @include above($tabletBreakpoint) {
         padding: map-get($configuration, notificationPaddingTopTablet)
@@ -118,6 +125,10 @@
 
         .notification[data-notification-status="draft"] {
           background-color: map-get($configuration, notificationDraftBackgroundColorTablet);
+        }
+
+        .notification[data-notification-status="published"] {
+          background-color: map-get($configuration, notificationPublishedBackgroundColorTablet);
         }
       }
 
@@ -130,6 +141,10 @@
 
         .notification[data-notification-status="draft"] {
           background-color: map-get($configuration, notificationDraftBackgroundColorDesktop);
+        }
+
+        .notification[data-notification-status="published"] {
+          background-color: map-get($configuration, notificationPublishedBackgroundColorDesktop);
         }
       }
     }

--- a/theme.json
+++ b/theme.json
@@ -30930,6 +30930,30 @@
                 "type": "color"
               },
               {
+                "name": "notificationPublishedBackgroundColor",
+                "default": "#ffffff",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.notificationinbox']",
+                    "selectors": ".notifications-holder .notification[data-notification-status='published']",
+                    "properties": ["background-color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "notificationPublishedBackgroundColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "notificationPublishedBackgroundColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Published notification background",
+                "type": "color"
+              },
+              {
                 "name": "notificationBadgeBackgroundColor",
                 "default": "#fe5857",
                 "columns": 12,


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4693

## Description
Added possibility to change background for published in-app notifications.

## Screenshots/screencasts
![published-inbox](https://user-images.githubusercontent.com/52824207/73924140-b24ed980-48d4-11ea-9a14-0bb13fd80dbf.gif)

## Backward compatibility
This change is fully backward compatible.