### PR TITLE
User can now configure text color in app list

### DIFF
--- a/scss/components/app-list.scss
+++ b/scss/components/app-list.scss
@@ -24,6 +24,7 @@
     appListPreparingIconColor: $appListPreparingIconColor,
     appListCompletedIconColor: $appListCompletedIconColor,
     appListInitialIconColor: $appListInitialIconColor,
+    appListTextColor: $appListTextColor,
     appListProgressBarColor: $appListProgressBarColor,
     appListProgressBarBGColor: $appListProgressBarBGColor,
     appListLoginOverlayColor: $appListLoginOverlayColor,
@@ -58,6 +59,7 @@
     appListPreparingIconColorTablet: $appListPreparingIconColorTablet,
     appListCompletedIconColorTablet: $appListCompletedIconColorTablet,
     appListInitialIconColorTablet: $appListInitialIconColorTablet,
+    appListTextColorTablet: $appListTextColorTablet,
     appListProgressBarColorTablet: $appListProgressBarColorTablet,
     appListProgressBarBGColorTablet: $appListProgressBarBGColorTablet,
     appListLoginOverlayColorTablet: $appListLoginOverlayColorTablet,
@@ -92,6 +94,7 @@
     appListPreparingIconColorDesktop: $appListPreparingIconColorDesktop,
     appListCompletedIconColorDesktop: $appListCompletedIconColorDesktop,
     appListInitialIconColorDesktop: $appListInitialIconColorDesktop,
+    appListTextColorDesktop: $appListTextColorDesktop,
     appListProgressBarColorDesktop: $appListProgressBarColorDesktop,
     appListProgressBarBGColorDesktop: $appListProgressBarBGColorDesktop,
     appListLoginOverlayColorDesktop: $appListLoginOverlayColorDesktop,
@@ -204,6 +207,21 @@
         // Styles for desktop
         @include above($desktopBreakpoint) {
           border-left-color: map-get($configuration, appListLoaderDesktop);
+        }
+      }
+
+      .list.list-default ul > li .list-swipe-holder .list-desc .list-title,
+      .app-list-content .no-apps-found-text {
+        color: map-get($configuration, appListTextColor);
+
+        // Styles for tablet
+        @include above($tabletBreakpoint) {
+          color: map-get($configuration, appListTextColorTablet);
+        }
+
+        // Styles for desktop
+        @include above($desktopBreakpoint) {
+          color: map-get($configuration, appListTextColorDesktop);
         }
       }
 

--- a/theme.json
+++ b/theme.json
@@ -16258,6 +16258,38 @@
             ]
           },
           {
+            "description": "Text color",
+            "fields": [
+              {
+                "name": "appListTextColor",
+                "default": "$bodyTextColor",
+                "column": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='app-list']",
+                    "selectors": [
+                      ".app-list .list.list-default ul > li .list-swipe-holder .list-desc .list-title",
+                      ".app-list .app-list-content .no-apps-found-text"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "appListTextColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "appListTextColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Text color",
+                "type": "color"
+              }
+            ]
+          },
+          {
             "description": "Progress bar",
             "fields": [
               {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4319

## Description
User can now edit color of warning message and apps title.

## Screenshots/screencasts
![theme-app-list](https://user-images.githubusercontent.com/52824207/74458593-9ded7c80-4e92-11ea-8df4-31d791f93194.gif)

## Backward compatibility
This change is fully backward compatible.