### PR TITLE
Show Visibility option on apps that support containers

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -4526,6 +4526,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "textVisibility",
@@ -5963,6 +5964,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "containerVisibility",
@@ -12690,6 +12692,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "primaryButtonVisibility",
@@ -14538,6 +14541,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "secondaryButtonVisibility",
@@ -21072,6 +21076,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "formVisibility",
@@ -21870,6 +21875,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "gridVisibility",
@@ -22944,6 +22950,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "imageVisibility",
@@ -25133,6 +25140,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "listVisibility",
@@ -26470,6 +26478,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "listSmallVisibility",
@@ -27807,6 +27816,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "listLargeVisibility",
@@ -28848,6 +28858,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "lfdVisibility",
@@ -29519,6 +29530,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "lockVisibility",
@@ -33380,6 +33392,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "panelVisibility",
@@ -34989,6 +35002,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "rssVisibility",
@@ -36254,6 +36268,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "slideVisibility",
@@ -38007,6 +38022,7 @@
           },
           {
             "description": "Visibility",
+            "appSupportsContainers": true,
             "fields": [
               {
                 "name": "videoVisibility",


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/5816

- This will prevent users using the old D&D system from hiding components and not being able to retrieve them.