### PR TITLE
Fix images responsiveness when inside flex containers on IE11

### DIFF
--- a/scss/components/images.scss
+++ b/scss/components/images.scss
@@ -109,6 +109,7 @@
   }
 
   #{$instanceSelector} {
+    flex-shrink: 0; /* Fix for IE11 when images are inside a flex container */
     position: map-get($configuration, imagePosition);
     z-index: map-get($configuration, imageIndex);
 


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/5937

- Image components will act as expected inside and outside flex containers