### PR TITLE
Tinymce border radius can be set by brush icon

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -802,7 +802,7 @@
         borderSides: map-get($configuration, formInputBorderSides)
       ));
 
-      border-radius: $formInputBorderRadius;
+      border-radius: map-get($configuration, formInputBorderRadius);
       overflow: hidden;
 
       // Styles for tablet

--- a/theme.json
+++ b/theme.json
@@ -20392,7 +20392,8 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-control",
-                      ".select-proxy-display"
+                      ".select-proxy-display",
+                      ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout"
                     ],
                     "properties": ["border-radius"]
                   },


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4724

## Description
Tinymce border-radius is also changing when using brush icon.

## Screenshots/screencasts
![borderRadius](https://user-images.githubusercontent.com/52824207/76853700-7f462100-6856-11ea-9d9a-44d10ce1583c.PNG)

## Backward compatibility
This change is fully backward compatible.