### PR TITLE
Simple list filters now looks correctly

### DIFF
--- a/scss/components/lists-data-source.scss
+++ b/scss/components/lists-data-source.scss
@@ -630,7 +630,7 @@
     }
 
     .new-news-feed-list-container .news-feed-search-filter-overlay,
-    .simple-list-search-filter-overlay,
+    .simple-list-container .simple-list-search-filter-overlay,
     .new-agenda-list-container .new-agenda-search-filter-overlay {
       .news-feed-overlay-wrapper,
       .simple-list-overlay-wrapper,


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6151

## Description
The issue was that selector was not specific enough.

## Screenshots/screencasts
![simple-list](https://user-images.githubusercontent.com/52824207/79012879-1198c680-7b70-11ea-98fa-05b1c0001038.gif)

## Backward compatibility
This change is fully backward compatible.