### PR TITLE
Accordion styles now are applied correctly

### DIFF
--- a/scss/components/accordions.scss
+++ b/scss/components/accordions.scss
@@ -127,54 +127,58 @@
     }
   }
 
-  .collapse-start {
-    color: map-get($configuration, accordionHeadingText);
-    background-color: map-get($configuration, accordionHeadingBg);
-    padding: map-get($configuration, accordionHeadingPaddingTop)
-      calc(#{map-get($configuration, accordionHeadingPaddingRight)} + 29px)
-      map-get($configuration, accordionHeadingPaddingBottom)
-      map-get($configuration, accordionHeadingPaddingLeft);
-    border: map-get($configuration, accordionBorderWidth)
-      map-get($configuration, accordionBorderStyle)
-      map-get($configuration, accordionBorderColor);
-
-    // Styles for tablet
-    @include above($tabletBreakpoint) {
-      color: map-get($configuration, accordionHeadingTextTablet);
-      background-color: map-get($configuration, accordionHeadingBgTablet);
-      padding: map-get($configuration, accordionHeadingPaddingTopTablet)
-        calc(#{map-get($configuration, accordionHeadingPaddingRightTablet)} + 29px)
-        map-get($configuration, accordionHeadingPaddingBottomTablet)
-        map-get($configuration, accordionHeadingPaddingLeftTablet);
-      border: map-get($configuration, accordionBorderWidthTablet)
-        map-get($configuration, accordionBorderStyleTablet)
-        map-get($configuration, accordionBorderColorTablet);
-    }
-
-    // Styles for desktop
-    @include above($desktopBreakpoint) {
-      color: map-get($configuration, accordionHeadingTextDesktop);
-      background-color: map-get($configuration, accordionHeadingBgDesktop);
-      padding: map-get($configuration, accordionHeadingPaddingTopDesktop)
-        calc(#{map-get($configuration, accordionHeadingPaddingRightDesktop)} + 29px)
-        map-get($configuration, accordionHeadingPaddingBottomDesktop)
-        map-get($configuration, accordionHeadingPaddingLeftDesktop);
-      border: map-get($configuration, accordionBorderWidthDesktop)
-        map-get($configuration, accordionBorderStyleDesktop)
-        map-get($configuration, accordionBorderColorDesktop);
-    }
-
-    &:after {
-      color: map-get($configuration, accordionHeadingChevron);
+  #{$instanceSelector},
+  #{$instanceWidgetStartSelector},
+  #{$instanceWidgetEndSelector} {
+    .collapse-start {
+      color: map-get($configuration, accordionHeadingText);
+      background-color: map-get($configuration, accordionHeadingBg);
+      padding: map-get($configuration, accordionHeadingPaddingTop)
+        calc(#{map-get($configuration, accordionHeadingPaddingRight)} + 29px)
+        map-get($configuration, accordionHeadingPaddingBottom)
+        map-get($configuration, accordionHeadingPaddingLeft);
+      border: map-get($configuration, accordionBorderWidth)
+        map-get($configuration, accordionBorderStyle)
+        map-get($configuration, accordionBorderColor);
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
-        color: map-get($configuration, accordionHeadingChevronTablet);
+        color: map-get($configuration, accordionHeadingTextTablet);
+        background-color: map-get($configuration, accordionHeadingBgTablet);
+        padding: map-get($configuration, accordionHeadingPaddingTopTablet)
+          calc(#{map-get($configuration, accordionHeadingPaddingRightTablet)} + 29px)
+          map-get($configuration, accordionHeadingPaddingBottomTablet)
+          map-get($configuration, accordionHeadingPaddingLeftTablet);
+        border: map-get($configuration, accordionBorderWidthTablet)
+          map-get($configuration, accordionBorderStyleTablet)
+          map-get($configuration, accordionBorderColorTablet);
       }
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
-        color: map-get($configuration, accordionHeadingChevronDesktop);
+        color: map-get($configuration, accordionHeadingTextDesktop);
+        background-color: map-get($configuration, accordionHeadingBgDesktop);
+        padding: map-get($configuration, accordionHeadingPaddingTopDesktop)
+          calc(#{map-get($configuration, accordionHeadingPaddingRightDesktop)} + 29px)
+          map-get($configuration, accordionHeadingPaddingBottomDesktop)
+          map-get($configuration, accordionHeadingPaddingLeftDesktop);
+        border: map-get($configuration, accordionBorderWidthDesktop)
+          map-get($configuration, accordionBorderStyleDesktop)
+          map-get($configuration, accordionBorderColorDesktop);
+      }
+
+      &:after {
+        color: map-get($configuration, accordionHeadingChevron);
+
+        // Styles for tablet
+        @include above($tabletBreakpoint) {
+          color: map-get($configuration, accordionHeadingChevronTablet);
+        }
+
+        // Styles for desktop
+        @include above($desktopBreakpoint) {
+          color: map-get($configuration, accordionHeadingChevronDesktop);
+        }
       }
     }
   }
@@ -396,5 +400,3 @@
 }
 
 @include accordion();
-
-


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5721

## Description
I only added lines 130-132 to have the same styles applied both in edit and preview modes.

## Screenshots/screencasts
![accordion-theme](https://user-images.githubusercontent.com/52824207/79331177-76af3c00-7f23-11ea-977a-b3679605059d.gif)

## Backward compatibility
This change is fully backward compatible.