### PR TITLE
[Fix] Appearance settings work correctly on menu style 'push in' with button on left

### DIFF
--- a/scss/components/menu-push-in.scss
+++ b/scss/components/menu-push-in.scss
@@ -249,7 +249,7 @@
       }
     }
 
-    .fl-menu-push-in {
+    .fl-menu-push-in, .fl-menu-push-in-left {
       .fl-menu-panel {
         background-color: map-get($configuration, menuPushBackgroundColor);
 


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6575

## Description
Fixed selectors in scss file.

## Screencast
![push-in](https://user-images.githubusercontent.com/52824207/84648583-e59e1680-af0d-11ea-8bc4-f8d55a7cac5d.PNG)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko