### PR TITLE
[Fix] LFD widget is now aligned on all screens.

### DIFF
--- a/scss/components/lfd/small-card.scss
+++ b/scss/components/lfd/small-card.scss
@@ -344,6 +344,10 @@
     $layoutSelector: '#{$instanceSelector}[data-id="#{$widgetInstanceId}"] #{$layout}';
   }
 
+  #{$instanceSelector} {
+    width: 100%;
+  }
+
   #{$layoutSelector} {
     position: map-get($configuration, lfdPosition) !important;
     z-index: map-get($configuration, lfdIndex);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6620

## Description
LFD widget is now aligned on all screens.

## Screenshots/screencasts
https://share.getcloudapp.com/nOuelmEG

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko