### PR TITLE
[Feature] Added possibility to change background color of signature field

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -53,6 +53,7 @@
     formSelectArrow: $formSelectArrow,
     formStarRating: $formStarRating,
     formStarRatingSelected: $formStarRatingSelected,
+    formSignatureFieldBackgroundColor: $formSignatureFieldBackgroundColor,
     formRequiredColor: $formRequiredColor,
     formVisibility: $formVisibility,
     formWidthTablet: $formWidthTablet,
@@ -108,6 +109,7 @@
     formSelectArrowTablet: $formSelectArrowTablet,
     formStarRatingTablet: $formStarRatingTablet,
     formStarRatingSelectedTablet: $formStarRatingSelectedTablet,
+    formSignatureFieldBackgroundColorTablet: $formSignatureFieldBackgroundColorTablet,
     formRequiredColorTablet: $formRequiredColorTablet,
     formVisibilityTablet: $formVisibilityTablet,
     formWidthDesktop: $formWidthDesktop,
@@ -163,6 +165,7 @@
     formSelectArrowDesktop: $formSelectArrowDesktop,
     formStarRatingDesktop: $formStarRatingDesktop,
     formStarRatingSelectedDesktop: $formStarRatingSelectedDesktop,
+    formSignatureFieldBackgroundColorDesktop: $formSignatureFieldBackgroundColorDesktop,
     formRequiredColorDesktop: $formRequiredColorDesktop,
     formVisibilityDesktop: $formVisibilityDesktop
   ), $options);
@@ -317,7 +320,7 @@
         }
       }
 
-      label{
+      label {
         &.control-label {
           color: map-get($configuration, formLabelColor);
           font-size: map-get($configuration, formLabelSize);
@@ -773,6 +776,20 @@
       // Styles for desktop
       @include above($desktopBreakpoint) {
         color: map-get($configuration, formStarRatingSelectedDesktop);
+      }
+    }
+
+    [_type="flSignature"] .field-signature {
+      background-color: map-get($configuration, formSignatureFieldBackgroundColor);
+
+      // Styles for tablet
+      @include above($tabletBreakpoint) {
+        background-color: map-get($configuration, formSignatureFieldBackgroundColorTablet);
+      }
+
+      // Styles for desktop
+      @include above($desktopBreakpoint) {
+        background-color: map-get($configuration, formSignatureFieldBackgroundColorDesktop);
       }
     }
 

--- a/theme.json
+++ b/theme.json
@@ -21077,6 +21077,35 @@
             ]
           },
           {
+            "description": "Signature field",
+            "fields": [
+              {
+                "name": "formSignatureFieldBackgroundColor",
+                "default": "$quickBackground",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": "[_type='flSignature'] .field-signature",
+                    "properties": ["background-color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formSignatureFieldBackgroundColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formSignatureFieldBackgroundColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Background color",
+                "type": "color"
+              }
+            ]
+          },
+          {
             "description": "Required fields note",
             "fields": [
               {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6624

## Description
The default color will be background color from quick settings.

## Screencast
https://streamable.com/qxe6pe

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko