### PR TITLE
[Feature] Added possibility to change styles text and placeholders of inputs

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -44,6 +44,20 @@
     formInputPaddingRight: $formInputPaddingRight,
     formInputPaddingBottom: $formInputPaddingBottom,
     formInputPaddingLeft: $formInputPaddingLeft,
+    formTextInputsFontFamily: $formTextInputsFontFamily,
+    formTextInputsFontSize: $formTextInputsFontSize,
+    formTextInputsFontColor: $formTextInputsFontColor,
+    formTextInputsFontWeight: $formTextInputsFontWeight,
+    formTextInputsItalic: $formTextInputsItalic,
+    formTextInputsUnderline: $formTextInputsUnderline,
+    formTextInputsLineHeight: $formTextInputsLineHeight,
+    formTextInputsPlaceholderFontFamily: $formTextInputsPlaceholderFontFamily,
+    formTextInputsPlaceholderFontSize: $formTextInputsPlaceholderFontSize,
+    formTextInputsPlaceholderFontColor: $formTextInputsPlaceholderFontColor,
+    formTextInputsPlaceholderFontWeight: $formTextInputsPlaceholderFontWeight,
+    formTextInputsPlaceholderItalic: $formTextInputsPlaceholderItalic,
+    formTextInputsPlaceholderUnderline: $formTextInputsPlaceholderUnderline,
+    formTextInputsPlaceholderLineHeight: $formTextInputsPlaceholderLineHeight,
     formToggleBackgroundColor: $formToggleBackgroundColor,
     formToggleBorderColor: $formToggleBorderColor,
     formToggleColor: $formToggleColor,
@@ -99,6 +113,20 @@
     formInputPaddingRightTablet: $formInputPaddingRightTablet,
     formInputPaddingBottomTablet: $formInputPaddingBottomTablet,
     formInputPaddingLeftTablet: $formInputPaddingLeftTablet,
+    formTextInputsFontFamilyTablet: $formTextInputsFontFamilyTablet,
+    formTextInputsFontSizeTablet: $formTextInputsFontSizeTablet,
+    formTextInputsFontColorTablet: $formTextInputsFontColorTablet,
+    formTextInputsFontWeightTablet: $formTextInputsFontWeightTablet,
+    formTextInputsItalicTablet: $formTextInputsItalicTablet,
+    formTextInputsUnderlineTablet: $formTextInputsUnderlineTablet,
+    formTextInputsLineHeightTablet: $formTextInputsLineHeightTablet,
+    formTextInputsPlaceholderFontFamilyTablet: $formTextInputsPlaceholderFontFamilyTablet,
+    formTextInputsPlaceholderFontSizeTablet: $formTextInputsPlaceholderFontSizeTablet,
+    formTextInputsPlaceholderFontColorTablet: $formTextInputsPlaceholderFontColorTablet,
+    formTextInputsPlaceholderFontWeightTablet: $formTextInputsPlaceholderFontWeightTablet,
+    formTextInputsPlaceholderItalicTablet: $formTextInputsPlaceholderItalicTablet,
+    formTextInputsPlaceholderUnderlineTablet: $formTextInputsPlaceholderUnderlineTablet,
+    formTextInputsPlaceholderLineHeightTablet: $formTextInputsPlaceholderLineHeightTablet,
     formToggleBackgroundColorTablet: $formToggleBackgroundColorTablet,
     formToggleBorderColorTablet: $formToggleBorderColorTablet,
     formToggleColorTablet: $formToggleColorTablet,
@@ -154,6 +182,20 @@
     formInputPaddingRightDesktop: $formInputPaddingRightDesktop,
     formInputPaddingBottomDesktop: $formInputPaddingBottomDesktop,
     formInputPaddingLeftDesktop: $formInputPaddingLeftDesktop,
+    formTextInputsFontFamilyDesktop: $formTextInputsFontFamilyDesktop,
+    formTextInputsFontSizeDesktop: $formTextInputsFontSizeDesktop,
+    formTextInputsFontColorDesktop: $formTextInputsFontColorDesktop,
+    formTextInputsFontWeightDesktop: $formTextInputsFontWeightDesktop,
+    formTextInputsItalicDesktop: $formTextInputsItalicDesktop,
+    formTextInputsUnderlineDesktop: $formTextInputsUnderlineDesktop,
+    formTextInputsLineHeightDesktop: $formTextInputsLineHeightDesktop,
+    formTextInputsPlaceholderFontFamilyDesktop: $formTextInputsPlaceholderFontFamilyDesktop,
+    formTextInputsPlaceholderFontSizeDesktop: $formTextInputsPlaceholderFontSizeDesktop,
+    formTextInputsPlaceholderFontColorDesktop: $formTextInputsPlaceholderFontColorDesktop,
+    formTextInputsPlaceholderFontWeightDesktop: $formTextInputsPlaceholderFontWeightDesktop,
+    formTextInputsPlaceholderItalicDesktop: $formTextInputsPlaceholderItalicDesktop,
+    formTextInputsPlaceholderUnderlineDesktop: $formTextInputsPlaceholderUnderlineDesktop,
+    formTextInputsPlaceholderLineHeightDesktop: $formTextInputsPlaceholderLineHeightDesktop,
     formToggleBackgroundColorDesktop: $formToggleBackgroundColorDesktop,
     formToggleBorderColorDesktop: $formToggleBorderColorDesktop,
     formToggleColorDesktop: $formToggleColorDesktop,
@@ -286,6 +328,86 @@
     }
 
     .form-group {
+      input.form-control {
+        @include fontOnly((
+          fontFamily: map-get($configuration, formTextInputsFontFamily),
+          fontSize: map-get($configuration, formTextInputsFontSize),
+          fontLineHeight: map-get($configuration, formTextInputsLineHeight),
+          fontWeight: map-get($configuration, formTextInputsFontWeight),
+          fontStyle: map-get($configuration, formTextInputsItalic),
+          fontDecoration: map-get($configuration, formTextInputsUnderline)
+        ));
+  
+        color: map-get($configuration, formTextInputsFontColor);
+
+        &::placeholder {
+          @include fontOnly((
+            fontFamily: map-get($configuration, formTextInputsPlaceholderFontFamily),
+            fontSize: map-get($configuration, formTextInputsPlaceholderFontSize),
+            fontLineHeight: map-get($configuration, formTextInputsPlaceholderLineHeight),
+            fontWeight: map-get($configuration, formTextInputsPlaceholderFontWeight),
+            fontStyle: map-get($configuration, formTextInputsPlaceholderItalic),
+            fontDecoration: map-get($configuration, formTextInputsPlaceholderUnderline)
+          ));
+    
+          color: map-get($configuration, formTextInputsPlaceholderFontColor);
+        }
+  
+        // Styles for tablet
+        @include above($tabletBreakpoint) {
+          @include fontOnly((
+            fontFamily: map-get($configuration, formTextInputsFontFamilyTablet),
+            fontSize: map-get($configuration, formTextInputsFontSizeTablet),
+            fontLineHeight: map-get($configuration, formTextInputsLineHeightTablet),
+            fontWeight: map-get($configuration, formTextInputsFontWeightTablet),
+            fontStyle: map-get($configuration, formTextInputsItalicTablet),
+            fontDecoration: map-get($configuration, formTextInputsUnderlineTablet)
+          ));
+  
+          color: map-get($configuration, formTextInputsFontColorTablet);
+
+          &::placeholder {
+            @include fontOnly((
+              fontFamily: map-get($configuration, formTextInputsPlaceholderFontFamilyTablet),
+              fontSize: map-get($configuration, formTextInputsPlaceholderFontSizeTablet),
+              fontLineHeight: map-get($configuration, formTextInputsPlaceholderLineHeightTablet),
+              fontWeight: map-get($configuration, formTextInputsPlaceholderFontWeightTablet),
+              fontStyle: map-get($configuration, formTextInputsPlaceholderItalicTablet),
+              fontDecoration: map-get($configuration, formTextInputsPlaceholderUnderlineTablet)
+            ));
+      
+            color: map-get($configuration, formTextInputsPlaceholderFontColorTablet);
+          }
+        }
+  
+        // Styles for desktop
+        @include above($desktopBreakpoint) {
+          @include fontOnly((
+            fontFamily: map-get($configuration, formTextInputsFontFamilyDesktop),
+            fontSize: map-get($configuration, formTextInputsFontSizeDesktop),
+            fontLineHeight: map-get($configuration, formTextInputsLineHeightDesktop),
+            fontWeight: map-get($configuration, formTextInputsFontWeightDesktop),
+            fontStyle: map-get($configuration, formTextInputsItalicDesktop),
+            fontDecoration: map-get($configuration, formTextInputsUnderlineDesktop)
+          ));
+  
+          color: map-get($configuration, formTextInputsFontColorDesktop);
+
+          &::placeholder {
+            @include fontOnly((
+              fontFamily: map-get($configuration, formTextInputsPlaceholderFontFamilyDesktop),
+              fontSize: map-get($configuration, formTextInputsPlaceholderFontSizeDesktop),
+              fontLineHeight: map-get($configuration, formTextInputsPlaceholderLineHeightDesktop),
+              fontWeight: map-get($configuration, formTextInputsPlaceholderFontWeightDesktop),
+              fontStyle: map-get($configuration, formTextInputsPlaceholderItalicDesktop),
+              fontDecoration: map-get($configuration, formTextInputsPlaceholderUnderlineDesktop)
+            ));
+      
+            color: map-get($configuration, formTextInputsPlaceholderFontColorDesktop);
+          }
+        }
+      }
+  
       .control-label {
         label {
           color: map-get($configuration, formLabelColor);

--- a/theme.json
+++ b/theme.json
@@ -20947,6 +20947,346 @@
             ]
           },
           {
+            "description": "Text inputs",
+            "fields": [
+              {
+                "name": "formTextInputsFontFamily",
+                "default": "$bodyFontFamily",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group .input-group input.form-control",
+                    "properties": ["font-family"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsFontFamilyTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsFontFamilyDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font",
+                "label": "Font"
+              },
+              {
+                "name": "formTextInputsFontSize",
+                "default": "14px",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group .input-group input.form-control",
+                    "properties": ["font-size"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsFontSizeTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsFontSizeDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subType": "font",
+                "label": "Font size"
+              },
+              {
+                "name": "formTextInputsFontColor",
+                "default": "rgb(85, 85, 85)",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group .input-group input.form-control",
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsFontColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsFontColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "color",
+                "label": "Font color"
+              },
+              {
+                "name": "formTextInputsFontWeight",
+                "default": "normal",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group .input-group input.form-control",
+                    "properties": ["font-weight"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsFontWeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsFontWeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "weight"
+              },
+              {
+                "name": "formTextInputsItalic",
+                "default": "normal",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group .input-group input.form-control",
+                    "properties": ["font-style"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsItalicTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsItalicDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "italic"
+              },
+              {
+                "name": "formTextInputsUnderline",
+                "default": "none",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group .input-group input.form-control",
+                    "properties": ["text-decoration"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsUnderlineTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsUnderlineDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "subType": "decoration",
+                "properties": "underline"
+              },
+              {
+                "name": "formTextInputsLineHeight",
+                "default": "20px",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group .input-group input.form-control",
+                    "properties": ["line-height"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsLineHeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsLineHeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subType": "line-height",
+                "label": "Line height"
+              }
+            ]
+          },
+          {
+            "description": "Text inputs placeholder",
+            "fields": [
+              {
+                "name": "formTextInputsPlaceholderFontFamily",
+                "default": "$formTextInputsFontFamily",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group input::placeholder",
+                    "properties": ["font-family"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsPlaceholderFontFamilyTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsPlaceholderFontFamilyDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font",
+                "label": "Font"
+              },
+              {
+                "name": "formTextInputsPlaceholderFontSize",
+                "default": "$formTextInputsFontSize",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group input::placeholder",
+                    "properties": ["font-size"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsPlaceholderFontSizeTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsPlaceholderFontSizeDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subType": "font",
+                "label": "Font size"
+              },
+              {
+                "name": "formTextInputsPlaceholderFontColor",
+                "default": "rgb(211, 211, 211)",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group input::placeholder",
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsPlaceholderFontColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsPlaceholderFontColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "color",
+                "label": "Font color"
+              },
+              {
+                "name": "formTextInputsPlaceholderFontWeight",
+                "default": "$formTextInputsFontWeight",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group input::placeholder",
+                    "properties": ["font-weight"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsPlaceholderFontWeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsPlaceholderFontWeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "weight"
+              },
+              {
+                "name": "formTextInputsPlaceholderItalic",
+                "default": "$formTextInputsItalic",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group input::placeholder",
+                    "properties": ["font-style"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsPlaceholderItalicTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsPlaceholderItalicDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "italic"
+              },
+              {
+                "name": "formTextInputsPlaceholderUnderline",
+                "default": "$formTextInputsUnderline",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group input::placeholder",
+                    "properties": ["text-decoration"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsPlaceholderUnderlineTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsPlaceholderUnderlineDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "subType": "decoration",
+                "properties": "underline"
+              },
+              {
+                "name": "formTextInputsPlaceholderLineHeight",
+                "default": "$formTextInputsLineHeight",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".form-group input::placeholder",
+                    "properties": ["line-height"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formTextInputsPlaceholderLineHeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formTextInputsPlaceholderLineHeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subType": "line-height",
+                "label": "Line height"
+              }
+            ]
+          },
+          {
             "description": "Dropdown",
             "fields": [
               {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6490

## Description
Added possibility to change styles text and placeholders of inputs.
Live changes on placeholders do not work and apparently there is no way to make them work.

## Screencast
![Capture](https://user-images.githubusercontent.com/52824207/87163984-d0c85f00-c2d0-11ea-800d-7580735fefa5.PNG)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko