### PR TITLE
[Feature] Added possibility to style extra fields in form builder

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -58,6 +58,13 @@
     formTextInputsPlaceholderItalic: $formTextInputsPlaceholderItalic,
     formTextInputsPlaceholderUnderline: $formTextInputsPlaceholderUnderline,
     formTextInputsPlaceholderLineHeight: $formTextInputsPlaceholderLineHeight,
+    formErrorTextFontFamily: $formErrorTextFontFamily,
+    formErrorTextFontSize: $formErrorTextFontSize,
+    formErrorTextFontColor: $formErrorTextFontColor,
+    formErrorTextFontWeight: $formErrorTextFontWeight,
+    formErrorTextItalic: $formErrorTextItalic,
+    formErrorTextUnderline: $formErrorTextUnderline,
+    formErrorTextLineHeight: $formErrorTextLineHeight,
     formToggleBackgroundColor: $formToggleBackgroundColor,
     formToggleBorderColor: $formToggleBorderColor,
     formToggleColor: $formToggleColor,
@@ -68,6 +75,8 @@
     formStarRating: $formStarRating,
     formStarRatingSelected: $formStarRatingSelected,
     formSignatureFieldBackgroundColor: $formSignatureFieldBackgroundColor,
+    formSignatureClearTextColor: $formSignatureClearTextColor,
+    formSignatureClearTextColorActive: $formSignatureClearTextColorActive,
     formRequiredColor: $formRequiredColor,
     formVisibility: $formVisibility,
     formWidthTablet: $formWidthTablet,
@@ -128,6 +137,13 @@
     formTextInputsPlaceholderItalicTablet: $formTextInputsPlaceholderItalicTablet,
     formTextInputsPlaceholderUnderlineTablet: $formTextInputsPlaceholderUnderlineTablet,
     formTextInputsPlaceholderLineHeightTablet: $formTextInputsPlaceholderLineHeightTablet,
+    formErrorTextFontFamilyTablet: $formErrorTextFontFamilyTablet,
+    formErrorTextFontSizeTablet: $formErrorTextFontSizeTablet,
+    formErrorTextFontColorTablet: $formErrorTextFontColorTablet,
+    formErrorTextFontWeightTablet: $formErrorTextFontWeightTablet,
+    formErrorTextItalicTablet: $formErrorTextItalicTablet,
+    formErrorTextUnderlineTablet: $formErrorTextUnderlineTablet,
+    formErrorTextLineHeightTablet: $formErrorTextLineHeightTablet,
     formToggleBackgroundColorTablet: $formToggleBackgroundColorTablet,
     formToggleBorderColorTablet: $formToggleBorderColorTablet,
     formToggleColorTablet: $formToggleColorTablet,
@@ -138,6 +154,8 @@
     formStarRatingTablet: $formStarRatingTablet,
     formStarRatingSelectedTablet: $formStarRatingSelectedTablet,
     formSignatureFieldBackgroundColorTablet: $formSignatureFieldBackgroundColorTablet,
+    formSignatureClearTextColorTablet: $formSignatureClearTextColorTablet,
+    formSignatureClearTextColorActiveTablet: $formSignatureClearTextColorActiveTablet,
     formRequiredColorTablet: $formRequiredColorTablet,
     formVisibilityTablet: $formVisibilityTablet,
     formWidthDesktop: $formWidthDesktop,
@@ -198,6 +216,13 @@
     formTextInputsPlaceholderItalicDesktop: $formTextInputsPlaceholderItalicDesktop,
     formTextInputsPlaceholderUnderlineDesktop: $formTextInputsPlaceholderUnderlineDesktop,
     formTextInputsPlaceholderLineHeightDesktop: $formTextInputsPlaceholderLineHeightDesktop,
+    formErrorTextFontFamilyDesktop: $formErrorTextFontFamilyDesktop,
+    formErrorTextFontSizeDesktop: $formErrorTextFontSizeDesktop,
+    formErrorTextFontColorDesktop: $formErrorTextFontColorDesktop,
+    formErrorTextFontWeightDesktop: $formErrorTextFontWeightDesktop,
+    formErrorTextItalicDesktop: $formErrorTextItalicDesktop,
+    formErrorTextUnderlineDesktop: $formErrorTextUnderlineDesktop,
+    formErrorTextLineHeightDesktop: $formErrorTextLineHeightDesktop,
     formToggleBackgroundColorDesktop: $formToggleBackgroundColorDesktop,
     formToggleBorderColorDesktop: $formToggleBorderColorDesktop,
     formToggleColorDesktop: $formToggleColorDesktop,
@@ -208,6 +233,8 @@
     formStarRatingDesktop: $formStarRatingDesktop,
     formStarRatingSelectedDesktop: $formStarRatingSelectedDesktop,
     formSignatureFieldBackgroundColorDesktop: $formSignatureFieldBackgroundColorDesktop,
+    formSignatureClearTextColorDesktop: $formSignatureClearTextColorDesktop,
+    formSignatureClearTextColorActiveDesktop: $formSignatureClearTextColorActiveDesktop,
     formRequiredColorDesktop: $formRequiredColorDesktop,
     formVisibilityDesktop: $formVisibilityDesktop
   ), $options);
@@ -496,6 +523,77 @@
       }
     }
 
+    .has-error {
+      .text-danger {
+        @include fontOnly((
+          fontFamily: map-get($configuration, formErrorTextFontFamily),
+          fontSize: map-get($configuration, formErrorTextFontSize),
+          fontLineHeight: map-get($configuration, formErrorTextLineHeight),
+          fontWeight: map-get($configuration, formErrorTextFontWeight),
+          fontStyle: map-get($configuration, formErrorTextItalic),
+          fontDecoration: map-get($configuration, formErrorTextUnderline)
+        ));
+
+        color: map-get($configuration, formErrorTextFontColor);
+
+        @include above($tabletBreakpoint) {
+          @include fontOnly((
+            fontFamily: map-get($configuration, formErrorTextFontFamilyTablet),
+            fontSize: map-get($configuration, formErrorTextFontSizeTablet),
+            fontLineHeight: map-get($configuration, formErrorTextLineHeightTablet),
+            fontWeight: map-get($configuration, formErrorTextFontWeightTablet),
+            fontStyle: map-get($configuration, formErrorTextItalicTablet),
+            fontDecoration: map-get($configuration, formErrorTextUnderlineTablet)
+          ));
+
+          color: map-get($configuration, formErrorTextFontColorTablet);
+        }
+  
+        @include above($desktopBreakpoint) {
+          @include fontOnly((
+            fontFamily: map-get($configuration, formErrorTextFontFamilyDesktop),
+            fontSize: map-get($configuration, formErrorTextFontSizeDesktop),
+            fontLineHeight: map-get($configuration, formErrorTextLineHeightDesktop),
+            fontWeight: map-get($configuration, formErrorTextFontWeightDesktop),
+            fontStyle: map-get($configuration, formErrorTextItalicDesktop),
+            fontDecoration: map-get($configuration, formErrorTextUnderlineDesktop)
+          ));
+
+          color: map-get($configuration, formErrorTextFontColorDesktop);
+        }
+      }
+
+      .form-control {
+        @include borderOnly((
+          borderSides: map-get($configuration, formInputBorderErrorSides),
+          borderWidth: map-get($configuration, formInputBorderErrorWidth),
+          borderStyle: map-get($configuration, formInputBorderErrorStyle),
+          borderColor: map-get($configuration, formInputBorderErrorColor)
+        ));
+        border-radius: map-get($configuration, formInputBorderErrorRadius);
+  
+        @include above($tabletBreakpoint) {
+          @include borderOnly((
+            borderSides: map-get($configuration, formInputBorderErrorSidesTablet),
+            borderWidth: map-get($configuration, formInputBorderErrorWidthTablet),
+            borderStyle: map-get($configuration, formInputBorderErrorStyleTablet),
+            borderColor: map-get($configuration, formInputBorderErrorColorTablet)
+          ));
+          border-radius: map-get($configuration, formInputBorderErrorRadiusTablet);
+        }
+  
+        @include above($desktopBreakpoint) {
+          @include borderOnly((
+            borderSides: map-get($configuration, formInputBorderErrorSidesDesktop),
+            borderWidth: map-get($configuration, formInputBorderErrorWidthDesktop),
+            borderStyle: map-get($configuration, formInputBorderErrorStyleDesktop),
+            borderColor: map-get($configuration, formInputBorderErrorColorDesktop)
+          ));
+          border-radius: map-get($configuration, formInputBorderErrorRadiusDesktop);
+        }
+      }
+    }
+
     .form-control {
       @include borderOnly((
         borderSides: map-get($configuration, formInputBorderSides),
@@ -508,16 +606,6 @@
         map-get($configuration, formInputPaddingRight)
         map-get($configuration, formInputPaddingBottom)
         map-get($configuration, formInputPaddingLeft);
-
-      &.has-error {
-        @include borderOnly((
-          borderSides: map-get($configuration, formInputBorderErrorSides),
-          borderWidth: map-get($configuration, formInputBorderErrorWidth),
-          borderStyle: map-get($configuration, formInputBorderErrorStyle),
-          borderColor: map-get($configuration, formInputBorderErrorColor)
-        ));
-        border-radius: map-get($configuration, formInputBorderErrorRadius);
-      }
 
       &:focus {
         @include borderOnly((
@@ -543,16 +631,6 @@
           map-get($configuration, formInputPaddingBottomTablet)
           map-get($configuration, formInputPaddingLeftTablet);
 
-        &.has-error {
-          @include borderOnly((
-            borderSides: map-get($configuration, formInputBorderErrorSidesTablet),
-            borderWidth: map-get($configuration, formInputBorderErrorWidthTablet),
-            borderStyle: map-get($configuration, formInputBorderErrorStyleTablet),
-            borderColor: map-get($configuration, formInputBorderErrorColorTablet)
-          ));
-          border-radius: map-get($configuration, formInputBorderErrorRadiusTablet);
-        }
-
         &:focus {
           @include borderOnly((
             borderSides: map-get($configuration, formInputBorderFocusSidesTablet),
@@ -577,16 +655,6 @@
           map-get($configuration, formInputPaddingRightDesktop)
           map-get($configuration, formInputPaddingBottomDesktop)
           map-get($configuration, formInputPaddingLeftDesktop);
-
-        &.has-error {
-          @include borderOnly((
-            borderSides: map-get($configuration, formInputBorderErrorSidesDesktop),
-            borderWidth: map-get($configuration, formInputBorderErrorWidthDesktop),
-            borderStyle: map-get($configuration, formInputBorderErrorStyleDesktop),
-            borderColor: map-get($configuration, formInputBorderErrorColorDesktop)
-          ));
-          border-radius: map-get($configuration, formInputBorderErrorRadiusDesktop);
-        }
 
         &:focus {
           @include borderOnly((
@@ -903,32 +971,63 @@
 
     [_type="flSignature"] .field-signature {
       background-color: map-get($configuration, formSignatureFieldBackgroundColor);
+      
+      canvas {
+        border: map-get($configuration, formInputBorderWidth) map-get($configuration, formInputBorderStyle) map-get($configuration, formInputBorderColor) !important;
+        border-top-width: 0 !important;
+        border-left-width: 0 !important;
+        border-right-width: 0 !important;
+      }
+
+      a {
+        color: map-get($configuration, formSignatureClearTextColor);
+
+        &:focus,
+        &:hover,
+        &:active:focus,
+        &:active:hover {
+          color: map-get($configuration, formSignatureClearTextColorActive);
+        }
+      }
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
         background-color: map-get($configuration, formSignatureFieldBackgroundColorTablet);
+
+        canvas {
+          border: map-get($configuration, formInputBorderWidthTablet) map-get($configuration, formInputBorderStyleTablet) map-get($configuration, formInputBorderColorTablet) !important;
+        }
+        
+        a {
+          color: map-get($configuration, formSignatureClearTextColorTablet);
+  
+          &:focus,
+          &:hover,
+          &:active:focus,
+          &:active:hover {
+            color: map-get($configuration, formSignatureClearTextColorActiveTablet);
+          }
+        }
       }
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
         background-color: map-get($configuration, formSignatureFieldBackgroundColorDesktop);
-      }
-    }
 
-    .field-signature canvas {
-      border: map-get($configuration, formInputBorderWidth) map-get($configuration, formInputBorderStyle) map-get($configuration, formInputBorderColor) !important;
-      border-top-width: 0 !important;
-      border-left-width: 0 !important;
-      border-right-width: 0 !important;
+        canvas {
+          border: map-get($configuration, formInputBorderWidthDesktop) map-get($configuration, formInputBorderStyleDesktop) map-get($configuration, formInputBorderColorDesktop) !important;
+        }
 
-      // Styles for tablet
-      @include above($tabletBreakpoint) {
-        border: map-get($configuration, formInputBorderWidthTablet) map-get($configuration, formInputBorderStyleTablet) map-get($configuration, formInputBorderColorTablet) !important;
-      }
-
-      // Styles for desktop
-      @include above($desktopBreakpoint) {
-        border: map-get($configuration, formInputBorderWidthDesktop) map-get($configuration, formInputBorderStyleDesktop) map-get($configuration, formInputBorderColorDesktop) !important;
+        a {
+          color: map-get($configuration, formSignatureClearTextColorDesktop);
+  
+          &:focus,
+          &:hover,
+          &:active:focus,
+          &:active:hover {
+            color: map-get($configuration, formSignatureClearTextColorActiveDesktop);
+          }
+        }
       }
     }
 

--- a/theme.json
+++ b/theme.json
@@ -20619,7 +20619,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-control.has-error",
+                    "selectors": ".has-error .form-control",
                     "properties": ["border-color"]
                   }
                 ],
@@ -20642,7 +20642,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-control.has-error",
+                    "selectors": ".has-error .form-control",
                     "properties": ["border-width"]
                   }
                 ],
@@ -20682,7 +20682,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-control.has-error",
+                    "selectors": ".has-error .form-control",
                     "properties": ["border-radius"]
                   }
                 ],
@@ -20904,7 +20904,7 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Icon",
+                "label": "Selected mark color",
                 "type": "color"
               },
               {
@@ -20941,7 +20941,7 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Icon",
+                "label": "Selected background color",
                 "type": "color"
               }
             ]
@@ -21287,6 +21287,176 @@
             ]
           },
           {
+            "description": "Error text",
+            "fields": [
+              {
+                "name": "formErrorTextFontFamily",
+                "default": "$quickTextFontFamily",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".has-error .text-danger",
+                    "properties": ["font-family"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formErrorTextFontFamilyTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formErrorTextFontFamilyDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font",
+                "label": "Font"
+              },
+              {
+                "name": "formErrorTextFontSize",
+                "default": "16px",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".has-error .text-danger",
+                    "properties": ["font-size"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formErrorTextFontSizeTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formErrorTextFontSizeDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subType": "font",
+                "label": "Font size"
+              },
+              {
+                "name": "formErrorTextFontColor",
+                "default": "#a94442",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".has-error .text-danger",
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formErrorTextFontColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formErrorTextFontColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "color",
+                "label": "Font color"
+              },
+              {
+                "name": "formErrorTextFontWeight",
+                "default": "normal",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".has-error .text-danger",
+                    "properties": ["font-weight"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formErrorTextFontWeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formErrorTextFontWeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "weight"
+              },
+              {
+                "name": "formErrorTextItalic",
+                "default": "normal",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".has-error .text-danger",
+                    "properties": ["font-style"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formErrorTextItalicTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formErrorTextItalicDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "properties": "italic"
+              },
+              {
+                "name": "formErrorTextUnderline",
+                "default": "none",
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".has-error .text-danger",
+                    "properties": ["text-decoration"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formErrorTextUnderlineTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formErrorTextUnderlineDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "font-style",
+                "subType": "decoration",
+                "properties": "underline"
+              },
+              {
+                "name": "formErrorTextLineHeight",
+                "default": "$bodyLineHeight",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": ".has-error .text-danger",
+                    "properties": ["line-height"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formErrorTextLineHeightTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formErrorTextLineHeightDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "size",
+                "subType": "line-height",
+                "label": "Line height"
+              }
+            ]
+          },
+          {
             "description": "Dropdown",
             "fields": [
               {
@@ -21387,7 +21557,7 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Unselected",
+                "label": "Unselected border color",
                 "type": "color"
               },
               {
@@ -21411,7 +21581,7 @@
                     "default": "inherit-tablet"
                   }
                 },
-                "label": "Selected",
+                "label": "Selected fill color",
                 "type": "color"
               }
             ]
@@ -21441,6 +21611,59 @@
                   }
                 },
                 "label": "Background color",
+                "type": "color"
+              },
+              {
+                "name": "formSignatureClearTextColor",
+                "default": "#aaa",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": "[_type='flSignature'] .field-signature a",
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formSignatureClearTextColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formSignatureClearTextColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Clear text color",
+                "type": "color"
+              },
+              {
+                "name": "formSignatureClearTextColorActive",
+                "default": "#0096B8",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
+                    "selectors": [
+                      "[_type='flSignature'] .field-signature a:hover",
+                      "[_type='flSignature'] .field-signature a:focus",
+                      "[_type='flSignature'] .field-signature a:active:hover",
+                      "[_type='flSignature'] .field-signature a:active:focus"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "formSignatureClearTextColorActiveTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "formSignatureClearTextColorActiveDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Clear text active color",
                 "type": "color"
               }
             ]


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6588

## Description
Added possibility to style "clear" text in the signature field and error message.
Also fixed some labels according to Ian's comment.

## Screencast
https://streamable.com/mauh1b

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko