### PR TITLE
[Feauture] Added possibility to style outlines

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -350,3 +350,34 @@ table.mce-item-table {
   }
 }
 
+// Outline
+
+.outline-item-selector:focus {
+  outline: none;
+
+  &:not(:hover) {
+    outline-color: $focusOutlineColor;
+    outline-width: $focusOutlineWidth;
+    outline-style: solid;
+  }
+  
+  @include above($tabletBreakpoint) {
+    outline: none;
+
+    &:not(:hover) {
+      outline-color: $focusOutlineColorTablet;
+      outline-width: $focusOutlineWidthTablet;
+      outline-style: solid;
+    }
+  }
+
+  @include above($desktopBreakpoint) {  
+    outline: none;
+
+    &:not(:hover) {
+      outline-color: $focusOutlineColorDesktop;
+      outline-width: $focusOutlineWidthDesktop;
+      outline-style: solid;
+    }
+  }
+}

--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -353,31 +353,25 @@ table.mce-item-table {
 // Outline
 
 .outline-item-selector:focus {
-  outline: none;
+  box-shadow: none;
 
   &:not(:hover) {
-    outline-color: $focusOutlineColor;
-    outline-width: $focusOutlineWidth;
-    outline-style: solid;
+    box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor;
   }
   
   @include above($tabletBreakpoint) {
-    outline: none;
+    box-shadow: none;
 
     &:not(:hover) {
-      outline-color: $focusOutlineColorTablet;
-      outline-width: $focusOutlineWidthTablet;
-      outline-style: solid;
+      box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet;
     }
   }
 
   @include above($desktopBreakpoint) {  
-    outline: none;
+    box-shadow: none;
 
     &:not(:hover) {
-      outline-color: $focusOutlineColorDesktop;
-      outline-width: $focusOutlineWidthDesktop;
-      outline-style: solid;
+      box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop;
     }
   }
 }

--- a/theme.json
+++ b/theme.json
@@ -199,6 +199,67 @@
             ]
           },
           {
+            "description": "Focus outline color",
+            "fields": [
+              {
+                "name": "focusOutlineColor",
+                "default": "rgba($highlightColor, 0.25)",
+                "column": 12,
+                "styles": [
+                  {
+                    "selectors": [
+                      ".outline-item-selector"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "focusOutlineColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "focusOutlineColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "color",
+                "label": "Color"
+              }
+           
+            ]
+          },
+          {
+            "description": "Focus outline width",
+            "fields": [
+              {
+                "name": "focusOutlineWidth",
+                "default": "2px",
+                "styles": [
+                  {
+                    "selectors": [
+                      ".outline-item-selector"
+                    ],
+                    "properties": ["width"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "focusOutlineWidthTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "focusOutlineWidthDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Width",
+                "type": "size",
+                "subtype": "all-props"
+              }
+            ]
+          },
+          {
             "description": "Paragraph",
             "appSupportsContainers": false,
             "fields": [


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#6420

## Description
To achieve outline only on focus by keyboard (and not on click) we are also checking if the element is not hovered. In the component, we then have to just add class "outline-item-selector" to the element we want to focus.

## Screencast
https://streamable.com/sgegno

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko