### PR TITLE
[Fix] Focus-within-outline

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -353,7 +353,7 @@ table.mce-item-table {
 // Outline
 
 .focus-outline:focus:not(:hover),
-.focus-within-outline:focus-within:not(:hover) {
+.focus-outline:focus-within:not(:hover) {
     box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
     outline: none;
   

--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -352,7 +352,8 @@ table.mce-item-table {
 
 // Outline
 
-.focus-outline:focus:not(:hover) {
+.focus-outline:focus:not(:hover),
+.focus-within-outline:focus-within:not(:hover) {
     box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
     outline: none;
   

--- a/theme.json
+++ b/theme.json
@@ -208,8 +208,7 @@
                 "styles": [
                   {
                     "selectors": [
-                      ".focus-outline",
-                      ".focus-within-outline"
+                      ".focus-outline"
                     ],
                     "properties": ["color"]
                   }

--- a/theme.json
+++ b/theme.json
@@ -208,7 +208,8 @@
                 "styles": [
                   {
                     "selectors": [
-                      ".focus-outline"
+                      ".focus-outline",
+                      ".focus-within-outline"
                     ],
                     "properties": ["color"]
                   }


### PR DESCRIPTION
@sofiiakvasnevska

##  Issue
Fliplet/fliplet-studio#6420

## Description
Sorry to bother again but we need an extra line of focus-within to target some pieces where input lies inside of label to which we need add box-shadow.

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko