### PR TITLE
[Fix] Remove default outline if there is any

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -352,16 +352,25 @@ table.mce-item-table {
 
 // Outline
 
-.focus-outline:focus:not(:hover),
-.focus-outline:focus-within:not(:hover) {
+.focus-outline:focus, .focus-outline:focus-within {
+  outline: none;
+
+  &:not(:hover) {
     box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
     outline: none;
-  
+  }
+
   @include above($tabletBreakpoint) {
-    box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet !important;
+    &:not(:hover) {
+      box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet !important;
+      outline: none;
+    }
   }
 
   @include above($desktopBreakpoint) {
-    box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop !important;
+    &:not(:hover) {
+      box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop !important;
+      outline: none;
+    }
   }
 }


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#6424

## Description
Removed default outline on focus if there is any.

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko