### PR TITLE
[Fix] Remove outline on touch devices when user taps on focussable UI

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -357,20 +357,17 @@ html.no-touchevents .focus-outline:focus, html.no-touchevents .focus-outline:foc
 
   &:not(:hover) {
     box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
-    outline: none;
   }
 
   @include above($tabletBreakpoint) {
     &:not(:hover) {
       box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet !important;
-      outline: none;
     }
   }
 
   @include above($desktopBreakpoint) {
     &:not(:hover) {
       box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop !important;
-      outline: none;
     }
   }
 }

--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -352,7 +352,7 @@ table.mce-item-table {
 
 // Outline
 
-.focus-outline:focus, .focus-outline:focus-within {
+html.no-touchevents .focus-outline:focus, html.no-touchevents .focus-outline:focus-within {
   outline: none;
 
   &:not(:hover) {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6424

## Description
Removed outline for touchable devices.

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko