### PR TITLE
[Fix] OD-83 Removed native outline for the touchable devices.

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -373,3 +373,11 @@ html.no-touchevents {
     }
   }
 }
+
+// Remove outline for native devices
+
+html.touchevents {
+  .focus-outline {
+    outline: none;
+  }
+}


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-83

## Description
Removed native outline for the touchable devices.

## Screenshots/screencasts
https://share.getcloudapp.com/Blu17XQO

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko