### PR TITLE
OD-352 [Feature] File name and info will look as in the mockup

### DIFF
--- a/scss/components/accordions.scss
+++ b/scss/components/accordions.scss
@@ -83,7 +83,10 @@
     accordionContentPaddingLeftDesktop: $accordionContentPaddingLeftDesktop,
     accordionBorderWidthDesktop: $accordionBorderWidthDesktop,
     accordionBorderStyleDesktop: $accordionBorderStyleDesktop,
-    accordionBorderColorDesktop: $accordionBorderColorDesktop
+    accordionBorderColorDesktop: $accordionBorderColorDesktop,
+    accordionContentBackgroundColor: $accordionContentBackgroundColor,
+    accordionContentBackgroundColorTablet: $accordionContentBackgroundColorTablet,
+    accordionContentBackgroundColorDesktop: $accordionContentBackgroundColorDesktop
   ), $options);
 
   $instanceSelector: '.panel';
@@ -371,7 +374,7 @@
       }
 
       .panel-body {
-        background-color: $bodyBackground;
+        background-color: map-get($configuration, accordionContentBackgroundColor);
         padding: map-get($configuration, accordionContentPaddingTop)
           map-get($configuration, accordionContentPaddingRight)
           map-get($configuration, accordionContentPaddingBottom)
@@ -379,7 +382,7 @@
 
         // Styles for tablet
         @include above($tabletBreakpoint) {
-          background-color: $bodyBackgroundTablet;
+          background-color: map-get($configuration, accordionContentBackgroundColorTablet);
           padding: map-get($configuration, accordionContentPaddingTopTablet)
             map-get($configuration, accordionContentPaddingRightTablet)
             map-get($configuration, accordionContentPaddingBottomTablet)
@@ -388,7 +391,7 @@
 
         // Styles for desktop
         @include above($desktopBreakpoint) {
-          background-color: $bodyBackgroundDesktop;
+          background-color: map-get($configuration, accordionContentBackgroundColorDesktop);
           padding: map-get($configuration, accordionContentPaddingTopDesktop)
             map-get($configuration, accordionContentPaddingRightDesktop)
             map-get($configuration, accordionContentPaddingBottomDesktop)

--- a/scss/components/lfd/agenda.scss
+++ b/scss/components/lfd/agenda.scss
@@ -299,7 +299,10 @@
   agendaAddButtonBackgroundDesktop: $agendaAddButtonBackgroundDesktop,
   agendaAddButtonIcon: $agendaAddButtonIcon,
   agendaAddButtonIconTablet: $agendaAddButtonIconTablet,
-  agendaAddButtonIconDesktop: $agendaAddButtonIconDesktop
+  agendaAddButtonIconDesktop: $agendaAddButtonIconDesktop,
+  agendaFileArrowColor: $agendaFileArrowColor,
+  agendaFileArrowColorTablet: $agendaFileArrowColorTablet,
+  agendaFileArrowColorDesktop: $agendaFileArrowColorDesktop
   ), $options);
 
   $instanceSelector: '[data-widget-package="com.fliplet.dynamic-lists"]';
@@ -384,6 +387,24 @@
     .agenda-detail-overlay {
       .agenda-detail-overlay-wrapper .agenda-detail-overlay-content {
         background-color: map-get($configuration, agendaListDetailOverlayBackground);
+      }
+
+      .file-holder {
+        .file-item {
+          .file-title {
+            color: $bodyTextColor;
+            font-weight: $bodyFontWeight;
+          }
+
+          .file-info {
+            font-size: $bodyFontSize * 0.85;
+            color: rgba($bodyTextColor, 0.5);
+          }
+
+          .file-icon {
+            color: map-get($configuration, smallCardListFileArrowColor);
+          }
+        }
       }
 
       .agenda-detail-overlay-panel {
@@ -487,6 +508,24 @@
               color: map-get($configuration, agendaDetailTextFontColorTablet);
             }
 
+            .file-holder {
+              .file-item {
+                .file-title {
+                  color: $bodyTextColorTablet;
+                  font-weight: $bodyFontWeightTablet;
+                }
+      
+                .file-info {
+                  font-size: $bodyFontSizeTablet * 0.85;
+                  color: rgba($bodyTextColorTablet, 0.5);
+                }
+      
+                .file-icon {
+                  color: map-get($configuration, smallCardListFileArrowColorTablet);
+                }
+              }
+            }
+
             .agenda-item-session-location {
               .agenda-item-start-date-time {
                 @include fontOnly((
@@ -568,6 +607,24 @@
               margin-top: map-get($configuration, agendaDetailTextMarginTopDesktop);
               margin-bottom: map-get($configuration, agendaDetailTextMarginBottomDesktop);
               color: map-get($configuration, agendaDetailTextFontColorDesktop);
+            }
+
+            .file-holder {
+              .file-item {
+                .file-title {
+                  color: $bodyTextColorDesktop;
+                  font-weight: $bodyFontWeightDesktop;
+                }
+      
+                .file-info {
+                  font-size: $bodyFontSizeDesktop * 0.85;
+                  color: rgba($bodyTextColorDesktop, 0.5);
+                }
+      
+                .file-icon {
+                  color: map-get($configuration, smallCardListFileArrowColorDesktop);
+                }
+              }
             }
 
             .agenda-item-session-location {

--- a/scss/components/lfd/news-feed.scss
+++ b/scss/components/lfd/news-feed.scss
@@ -317,7 +317,10 @@
   newsFeedAddButtonIconDesktop: $newsFeedAddButtonIconDesktop,
   newsFeedSortIconColor: $newsFeedSortIconColor,
   newsFeedSortIconColorTablet: $newsFeedSortIconColorTablet,
-  newsFeedSortIconColorDesktop: $newsFeedSortIconColorDesktop
+  newsFeedSortIconColorDesktop: $newsFeedSortIconColorDesktop,
+  newsFeedFileArrowColor: $newsFeedFileArrowColor,
+  newsFeedFileArrowColorTablet: $newsFeedFileArrowColorTablet,
+  newsFeedFileArrowColorDesktop: $newsFeedFileArrowColorDesktop
   ), $options);
 
   $instanceSelector: '[data-widget-package="com.fliplet.dynamic-lists"]';
@@ -1148,6 +1151,24 @@
             color: map-get($configuration, newsFeedDetailTextFontColor);
           }
 
+          .file-holder {
+            .file-item {
+              .file-title {
+                color: $bodyTextColor;
+                font-weight: $bodyFontWeight;
+              }
+
+              .file-info {
+                font-size: $bodyFontSize * 0.85;
+                color: rgba($bodyTextColor, 0.5);
+              }
+
+              .file-icon {
+                color: map-get($configuration, newsFeedFileArrowColor);
+              }
+            }
+          }
+
           .news-feed-info-holder {
             .news-feed-date-category {
               @include fontOnly((
@@ -1280,6 +1301,24 @@
             background-color: map-get($configuration, newsFeedImageBackgroundTablet);
           }
 
+          .file-holder {
+            .file-item {
+              .file-title {
+                color: $bodyTextColorTablet;
+                font-weight: $bodyFontWeightTablet;
+              }
+
+              .file-info {
+                font-size: $bodyFontSizeTablet * 0.85;
+                color: rgba($bodyTextColorTablet, 0.5);
+              }
+
+              .file-icon {
+                color: map-get($configuration, newsFeedFileArrowColorTablet);
+              }
+            }
+          }
+
           .news-feed-detail-overlay-close {
             color: map-get($configuration, newsFeedDetailTitleFontColorTablet);
           }
@@ -1374,6 +1413,24 @@
           .news-feed-list-detail-image-wrapper {
             color: rgba(map-get($configuration, newsFeedDetailTitleFontColorDesktop), 0.1);
             background-color: map-get($configuration, newsFeedImageBackgroundDesktop);
+          }
+
+          .file-holder {
+            .file-item {
+              .file-title {
+                color: $bodyTextColorDesktop;
+                font-weight: $bodyFontWeightDesktop;
+              }
+
+              .file-info {
+                font-size: $bodyFontSizeDesktop * 0.85;
+                color: rgba($bodyTextColorDesktop, 0.5);
+              }
+
+              .file-icon {
+                color: map-get($configuration, newsFeedFileArrowColorDesktop);
+              }
+            }
           }
 
           .news-feed-detail-overlay-close {

--- a/scss/components/lfd/simple-list.scss
+++ b/scss/components/lfd/simple-list.scss
@@ -279,6 +279,9 @@
     simpleListSortIconColor: $simpleListSortIconColor,
     simpleListSortIconColorTablet: $simpleListSortIconColorTablet,
     simpleListSortIconColorDesktop: $simpleListSortIconColorDesktop,
+    simpleListFileArrowColor: $simpleListFileArrowColor,
+    simpleListFileArrowColorTablet: $simpleListFileArrowColorTablet,
+    simpleListFileArrowColorDesktop: $simpleListFileArrowColorDesktop
   ), $options);
 
   $instanceSelector: '[data-widget-package="com.fliplet.dynamic-lists"]';
@@ -1142,6 +1145,24 @@
         background-color: map-get($configuration, simpleListImageBackground);
       }
 
+      .file-holder {
+        .file-item {
+          .file-title {
+            color: $bodyTextColor;
+            font-weight: $bodyFontWeight;
+          }
+
+          .file-info {
+            font-size: $bodyFontSize * 0.85;
+            color: rgba($bodyTextColor, 0.5);
+          }
+
+          .file-icon {
+            color: map-get($configuration, smallCardListFileArrowColor);
+          }
+        }
+      }
+
       .simple-list-detail-value {
         @include fontOnly((
           fontFamily: map-get($configuration, simpleListDetailTextFontFamily),
@@ -1196,6 +1217,24 @@
 
         .simple-list-detail-value img {
           background-color: map-get($configuration, simpleListImageBackgroundTablet);
+        }
+
+        .file-holder {
+          .file-item {
+            .file-title {
+              color: $bodyTextColorTablet;
+              font-weight: $bodyFontWeightTablet;
+            }
+  
+            .file-info {
+              font-size: $bodyFontSizeTablet * 0.85;
+              color: rgba($bodyTextColorTablet, 0.5);
+            }
+  
+            .file-icon {
+              color: map-get($configuration, simpleListFileArrowColorTablet);
+            }
+          }
         }
 
         .simple-list-detail-value {
@@ -1253,6 +1292,24 @@
 
         .simple-list-detail-value img {
           background-color: map-get($configuration, simpleListImageBackgroundDesktop);
+        }
+
+        .file-holder {
+          .file-item {
+            .file-title {
+              color: $bodyTextColorDesktop;
+              font-weight: $bodyFontWeightDesktop;
+            }
+  
+            .file-info {
+              font-size: $bodyFontSizeDesktop * 0.85;
+              color: rgba($bodyTextColorDesktop, 0.5);
+            }
+  
+            .file-icon {
+              color: map-get($configuration, simpleListFileArrowColorDesktop);
+            }
+          }
         }
 
         .simple-list-detail-value {

--- a/scss/components/lfd/small-card.scss
+++ b/scss/components/lfd/small-card.scss
@@ -347,10 +347,13 @@
     smallCardAddButtonIconDesktop: $smallCardAddButtonIconDesktop,
     smallCardSortIconColor: $smallCardSortIconColor,
     smallCardSortIconColorTablet: $smallCardSortIconColorTablet,
-    smallCardSortIconColorDesktop: $smallCardSortIconColorDesktop
+    smallCardSortIconColorDesktop: $smallCardSortIconColorDesktop,
+    smallCardListFileArrowColor: $smallCardListFileArrowColor,
+    smallCardListFileArrowColorTablet: $smallCardListFileArrowColorTablet,
+    smallCardListFileArrowColorDesktop: $smallCardListFileArrowColorDesktop
   ), $options);
 
-  $instanceSelector: '[data-widget-package="com.fliplet.dynamic-lists"]';
+  $instanceSelector: '[data-widget-package="com.fliplet.dynamic-lists-yaroslav"]';
   $layout: '[data-settings-layout="small-card"]';
   $layoutSelector: '#{$instanceSelector}#{$layout}';
   @if $widgetInstanceUUID != '' {
@@ -939,6 +942,24 @@
             margin-bottom: map-get($configuration, smallCardDetailLabelsMarginBottom);
             color: map-get($configuration, smallCardDetailLabelsFontColor);
           }
+
+          .file-holder {
+            .file-item {
+              .file-title {
+                color: $bodyTextColor;
+                font-weight: $bodyFontWeight;
+              }
+
+              .file-info {
+                font-size: $bodyFontSize * 0.85;
+                color: rgba($bodyTextColor, 0.5);
+              }
+
+              .file-icon {
+                color: map-get($configuration, smallCardListFileArrowColor);
+              }
+            }
+          }
         }
 
         .small-card-list-detail-image-wrapper {
@@ -1032,6 +1053,24 @@
               margin-top: map-get($configuration, smallCardDetailTextMarginTopTablet);
               margin-bottom: map-get($configuration, smallCardDetailTextMarginBottomTablet);
               color: map-get($configuration, lfdDetailFontColorTablet);
+            }
+
+            .file-holder {
+              .file-item {
+                .file-title {
+                  color: $bodyTextColorTablet;
+                  font-weight: $bodyFontWeightTablet;
+                }
+  
+                .file-info {
+                  font-size: $bodyFontSizeTablet * 0.85;
+                  color: rgba($bodyTextColorTablet, 0.5);
+                }
+  
+                .file-icon {
+                  color: map-get($configuration, smallCardListFileArrowColorTablet);
+                }
+              }
             }
 
             .small-card-list-detail-label {
@@ -1142,6 +1181,24 @@
               margin-top: map-get($configuration, smallCardDetailTextMarginTopDesktop);
               margin-bottom: map-get($configuration, smallCardDetailTextMarginBottomDesktop);
               color: map-get($configuration, lfdDetailFontColorDesktop);
+            }
+
+            .file-holder {
+              .file-item {
+                .file-title {
+                  color: $bodyTextColorDesktop;
+                  font-weight: $bodyFontWeightDesktop;
+                }
+  
+                .file-info {
+                  font-size: $bodyFontSizeDesktop * 0.85;
+                  color: rgba($bodyTextColorDesktop, 0.5);
+                }
+  
+                .file-icon {
+                  color: map-get($configuration, smallCardListFileArrowColorDesktop);
+                }
+              }
             }
 
             .small-card-list-detail-label {

--- a/scss/components/lfd/small-h-card.scss
+++ b/scss/components/lfd/small-h-card.scss
@@ -257,7 +257,10 @@
   smallHCardPositionBottomDesktop: $smallHCardPositionBottomDesktop,
   smallHCardPositionLeftDesktop: $smallHCardPositionLeftDesktop,
   smallHCardIndexDesktop: $smallHCardIndexDesktop,
-  smallHCardDisplayDesktop: $smallHCardDisplayDesktop
+  smallHCardDisplayDesktop: $smallHCardDisplayDesktop,
+  smallHCardListFileArrowColor: $smallHCardListFileArrowColor,
+  smallHCardListFileArrowColorTablet: $smallHCardListFileArrowColorTablet,
+  smallHCardListFileArrowColorDesktop: $smallHCardListFileArrowColorDesktop
   ), $options);
 
   $instanceSelector: '[data-widget-package="com.fliplet.dynamic-lists"]';
@@ -415,6 +418,24 @@
         background-color: map-get($configuration, smallHCardBackgroundColor);
       }
 
+      .file-holder {
+        .file-item {
+          .file-title {
+            color: $bodyTextColor;
+            font-weight: $bodyFontWeight;
+          }
+
+          .file-info {
+            font-size: $bodyFontSize * 0.85;
+            color: rgba($bodyTextColor, 0.5);
+          }
+
+          .file-icon {
+            color: map-get($configuration, smallHCardListFileArrowColor);
+          }
+        }
+      }
+
       .small-h-card-list-detail-name {
         color: map-get($configuration, smallHCardFontColor);
 
@@ -503,6 +524,24 @@
           background-color: map-get($configuration, smallHCardBackgroundColorTablet);
         }
 
+        .file-holder {
+          .file-item {
+            .file-title {
+              color: $bodyTextColorTablet;
+              font-weight: $bodyFontWeightTablet;
+            }
+  
+            .file-info {
+              font-size: $bodyFontSizeTablet * 0.85;
+              color: rgba($bodyTextColorTablet, 0.5);
+            }
+  
+            .file-icon {
+              color: map-get($configuration, smallHCardListFileArrowColorTablet);
+            }
+          }
+        }
+
         .small-h-card-list-detail-name {
           color: map-get($configuration, smallHCardFontColorTablet);
         }
@@ -587,6 +626,24 @@
 
         .small-h-card-list-detail-content-wrapper {
           background-color: map-get($configuration, smallHCardBackgroundColorDesktop);
+        }
+
+        .file-holder {
+          .file-item {
+            .file-title {
+              color: $bodyTextColorDesktop;
+              font-weight: $bodyFontWeightDesktop;
+            }
+  
+            .file-info {
+              font-size: $bodyFontSizeDesktop * 0.85;
+              color: rgba($bodyTextColorDesktop, 0.5);
+            }
+  
+            .file-icon {
+              color: map-get($configuration, smallHCardListFileArrowColorDesktop);
+            }
+          }
         }
 
         .small-h-card-list-detail-name {

--- a/theme.json
+++ b/theme.json
@@ -31249,7 +31249,7 @@
                 "type": "color"
               }
             ]
-          },  
+          },
           {
             "description": "List item border",
             "fields": [

--- a/theme.json
+++ b/theme.json
@@ -31221,9 +31221,35 @@
                 },
                 "label": "Sort icon",
                 "type": "color"
+              },
+              {
+                "name": "smallCardListFileArrowColor",
+                "default": "$smallCardListDetailOverlayIconsColor",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.dynamic-lists'][data-settings-layout='small-card']",
+                    "selectors": [
+                      ".new-small-card-list-container .section-top-wrapper .list-search-icon .fa-sort-amount-desc"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "smallCardListFileArrowColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "smallCardListFileArrowColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Arrow color",
+                "type": "color"
               }
             ]
-          },
+          },  
           {
             "description": "List item border",
             "fields": [
@@ -34121,6 +34147,32 @@
                 },
                 "label": "Sort icon",
                 "type": "color"
+              },
+              {
+                "name": "newsFeedFileArrowColor",
+                "default": "$smallCardListDetailOverlayIconsColor",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.dynamic-lists'][data-settings-layout='news-feed']",
+                    "selectors": [
+                      ".new-small-card-list-container .section-top-wrapper .list-search-icon .fa-sort-amount-desc"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "newsFeedFileArrowColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "newsFeedFileArrowColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Arrow color",
+                "type": "color"
               }
             ]
           },
@@ -36813,6 +36865,32 @@
                 },
                 "label": "Add button icon color",
                 "type": "color"
+              },
+              {
+                "name": "agendaFileArrowColor",
+                "default": "$agendaListDetailOverlayIconsColor",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.dynamic-lists'][data-settings-layout='agenda']",
+                    "selectors": [
+                      ".new-small-card-list-container .section-top-wrapper .list-search-icon .fa-sort-amount-desc"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "agendaFileArrowColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "agendaFileArrowColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Arrow color",
+                "type": "color"
               }
             ]
           },
@@ -39157,7 +39235,7 @@
                 "columns": 12,
                 "styles": [
                   {
-                    "parentSelector": "[data-widget-package='com.fliplet.dynamic-lists'][data-settings-layout='small-card']",
+                    "parentSelector": "[data-widget-package='com.fliplet.dynamic-lists'][data-settings-layout='small-h-card']",
                     "selectors": [
                       ".new-small-h-card-list-container .small-h-card-list-detail-image-wrapper",
                       ".small-h-card-detail-overlay .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-panel .small-h-card-detail-wrapper .small-h-card-list-detail-image-wrapper"
@@ -39176,6 +39254,32 @@
                   }
                 },
                 "label": "Image area background",
+                "type": "color"
+              },
+              {
+                "name": "smallHCardListFileArrowColor",
+                "default": "$smallHCardListDetailOverlayIconsColor",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.dynamic-lists'][data-settings-layout='small-h-card']",
+                    "selectors": [
+                      ".new-small-card-list-container .section-top-wrapper .list-search-icon .fa-sort-amount-desc"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "smallHCardListFileArrowColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "smallHCardListFileArrowColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Arrow color",
                 "type": "color"
               }
             ]
@@ -41797,6 +41901,32 @@
                   }
                 },
                 "label": "Sort icon",
+                "type": "color"
+              },
+              {
+                "name": "simpleListFileArrowColor",
+                "default": "$simpleListDetailOverlayIconsColor",
+                "columns": 12,
+                "styles": [
+                  {
+                    "parentSelector": "[data-widget-package='com.fliplet.dynamic-lists'][data-settings-layout='simple-list']",
+                    "selectors": [
+                      ".new-small-card-list-container .section-top-wrapper .list-search-icon .fa-sort-amount-desc"
+                    ],
+                    "properties": ["color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "simpleListFileArrowColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "simpleListFileArrowColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "label": "Arrow color",
                 "type": "color"
               }
             ]

--- a/theme.json
+++ b/theme.json
@@ -15492,6 +15492,35 @@
             ]
           },
           {
+            "description": "Content",
+            "fields": [
+              {
+                "name": "accordionContentBackgroundColor",
+                "default": "$bodyBackground",
+                "columns": 12,
+                "styles": [
+                  {
+                  "parentSelector": ".panel-group .panel",
+                  "selectors": ".panel-body",
+                  "properties": ["background-color"]
+                  }
+                ],
+                "breakpoints": {
+                  "tablet": {
+                    "name": "accordionContentBackgroundColorTablet",
+                    "default": "inherit-mobile"
+                  },
+                  "desktop": {
+                    "name": "accordionContentBackgroundColorDesktop",
+                    "default": "inherit-tablet"
+                  }
+                },
+                "type": "color",
+                "label": "Background"
+              }
+            ]
+          },
+          {
             "description": "Content padding",
             "fields": [
               {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-352

## Description
Added File Title font size as in `bodyfontSize` and file info as 85% from the `bodyfontSize`

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/110821364-aaf8bd00-8298-11eb-83e4-ae9f5bf38d03.png)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko @ivandevupp

## Notes
This will work only with the [OD-19](https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/517)