### PR TITLE
OD-426 [Fix] Users will see correct box-shadow when element isn't hovered.

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -382,20 +382,20 @@ html.no-touchevents.js-focus-visible {
   .focus-outline-active, .focus-outline {
     outline: none;
 
-    &:focus {
+    &:focus.focus-visible {
       box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
     }
 
     &:focus:not(.focus-visible) {
-      box-shadow: none !important;
+      box-shadow: none;
     }
 
     &:not(:focus-visible) {
-      box-shadow: none !important;
+      box-shadow: none;
     }
 
     &:focus-visible {
-      box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
+      box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor;
     }
 
     @include above($tabletBreakpoint) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-426

## Description
Removed `!important` from `box-shadow: none` to allow the use of the default box-shadow when an element isn't selected by the Tab key.

## Screenshots/screencasts
https://share.getcloudapp.com/Koudze08

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko @ivandevupp @AndrRyaz