### PR TITLE
OD-426 [Fix] Users will be able to see default box shadows on the tablet and desktops.

### DIFF
--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -380,15 +380,8 @@ table.mce-item-table {
 
 html.no-touchevents.js-focus-visible {
   .focus-outline-active, .focus-outline {
-    outline: none;
-
     &:focus.focus-visible {
       box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
-    }
-
-    &:focus:not(.focus-visible),
-    &:not(:focus-visible) {
-      box-shadow: none;
     }
 
     &:focus-visible {
@@ -400,11 +393,6 @@ html.no-touchevents.js-focus-visible {
         box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet !important;
       }
   
-      &:focus:not(.focus-visible),
-      &:not(:focus-visible) {
-        box-shadow: none;
-      }
-  
       &:focus-visible {
         box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet;
       }
@@ -413,11 +401,6 @@ html.no-touchevents.js-focus-visible {
     @include above($desktopBreakpoint) {
       &:focus {
         box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop !important;
-      }
-  
-      &:focus:not(.focus-visible),
-      &:not(:focus-visible) {
-        box-shadow: none;
       }
   
       &:focus-visible {

--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -386,10 +386,7 @@ html.no-touchevents.js-focus-visible {
       box-shadow: 0px 0px 0px $focusOutlineWidth $focusOutlineColor !important;
     }
 
-    &:focus:not(.focus-visible) {
-      box-shadow: none;
-    }
-
+    &:focus:not(.focus-visible),
     &:not(:focus-visible) {
       box-shadow: none;
     }
@@ -403,10 +400,7 @@ html.no-touchevents.js-focus-visible {
         box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet !important;
       }
   
-      &:focus:not(.focus-visible) {
-        box-shadow: none;
-      }
-  
+      &:focus:not(.focus-visible),
       &:not(:focus-visible) {
         box-shadow: none;
       }
@@ -421,10 +415,7 @@ html.no-touchevents.js-focus-visible {
         box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop !important;
       }
   
-      &:focus:not(.focus-visible) {
-        box-shadow: none;
-      }
-  
+      &:focus:not(.focus-visible),
       &:not(:focus-visible) {
         box-shadow: none;
       }

--- a/scss/core/base.scss
+++ b/scss/core/base.scss
@@ -404,15 +404,15 @@ html.no-touchevents.js-focus-visible {
       }
   
       &:focus:not(.focus-visible) {
-        box-shadow: none !important;
+        box-shadow: none;
       }
   
       &:not(:focus-visible) {
-        box-shadow: none !important;
+        box-shadow: none;
       }
   
       &:focus-visible {
-        box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet !important;
+        box-shadow: 0px 0px 0px $focusOutlineWidthTablet $focusOutlineColorTablet;
       }
     }
 
@@ -422,15 +422,15 @@ html.no-touchevents.js-focus-visible {
       }
   
       &:focus:not(.focus-visible) {
-        box-shadow: none !important;
+        box-shadow: none;
       }
   
       &:not(:focus-visible) {
-        box-shadow: none !important;
+        box-shadow: none;
       }
   
       &:focus-visible {
-        box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop !important;
+        box-shadow: 0px 0px 0px $focusOutlineWidthDesktop $focusOutlineColorDesktop;
       }
     }
   }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-426

## Description
Removed unneeded `!important` for tablet and desktop views.

## Screenshots/screencasts
https://share.getcloudapp.com/WnuYwrO0

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko @ivandevupp