### PR TITLE
OD-337 [Fix] Make all line height fields in all appearances have a list of units that includes the "x" unit

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -21203,7 +21203,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -21373,7 +21373,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -21543,7 +21543,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -29247,7 +29247,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -29465,7 +29465,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -29683,7 +29683,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -29901,7 +29901,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -30071,7 +30071,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -30289,7 +30289,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -30507,7 +30507,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -30725,7 +30725,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -32362,7 +32362,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -32580,7 +32580,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -32798,7 +32798,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -32968,7 +32968,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -33138,7 +33138,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -33356,7 +33356,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -33528,7 +33528,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -35030,7 +35030,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -35248,7 +35248,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -35466,7 +35466,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -35636,7 +35636,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -35806,7 +35806,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -36024,7 +36024,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -36244,7 +36244,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -37953,7 +37953,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -38171,7 +38171,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               }
             ]
@@ -38341,7 +38341,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -38559,7 +38559,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -38779,7 +38779,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -38999,7 +38999,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -40317,7 +40317,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -40535,7 +40535,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -40753,7 +40753,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -40971,7 +40971,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {
@@ -41189,7 +41189,7 @@
                   }
                 },
                 "type": "size",
-                "subType": "line-height",
+                "subtype": "line-height",
                 "label": "Line height"
               },
               {


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-337 https://weboo.atlassian.net/browse/OD-337
## Description
Made all line height fields in all appearances have a list of units that includes the "x" unit by fixing config names.
## Screenshots/screencasts
https://monosnap.com/file/T3Go6vyRW7tpKGAOBxaGshNqQPW7zL
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz @YaroslavOvdii