### PR TITLE
OD-158 [Feature] Allow users to set correct detail view icons color

### DIFF
--- a/scss/components/lfd/small-card.scss
+++ b/scss/components/lfd/small-card.scss
@@ -898,16 +898,9 @@
             color: map-get($configuration, smallCardDetailSecondDescriptionFontColor);
           }
 
-          .small-card-list-detail-button a {
+          .small-card-list-detail-button .small-card-list-detail-button-image,
+          .small-card-list-detail-button .small-card-list-detail-button-text {
             color: map-get($configuration, smallCardListDetailOverlayIconsColor);
-
-            &:hover,
-            &:focus,
-            &:active,
-            &:active:hover,
-            &:active:focus {
-              color: map-get($configuration, smallCardListDetailOverlayIconsColor);
-            }
           }
 
           .small-card-list-detail-body-text {
@@ -1007,16 +1000,9 @@
               color: map-get($configuration, smallCardDetailSecondDescriptionFontColorTablet);
             }
 
-            .small-card-list-detail-button a {
+            .small-card-list-detail-button .small-card-list-detail-button-image,
+            .small-card-list-detail-button .small-card-list-detail-button-text {
               color: map-get($configuration, smallCardListDetailOverlayIconsColorTablet);
-
-              &:hover,
-              &:focus,
-              &:active,
-              &:active:hover,
-              &:active:focus {
-                color: map-get($configuration, smallCardListDetailOverlayIconsColorTablet);
-              }
             }
 
             .small-card-list-detail-body-text {
@@ -1117,16 +1103,9 @@
               color: map-get($configuration, smallCardDetailSecondDescriptionFontColorDesktop);
             }
 
-            .small-card-list-detail-button a {
+            .small-card-list-detail-button .small-card-list-detail-button-image,
+            .small-card-list-detail-button .small-card-list-detail-button-text {
               color: map-get($configuration, smallCardListDetailOverlayIconsColorDesktop);
-
-              &:hover,
-              &:focus,
-              &:active,
-              &:active:hover,
-              &:active:focus {
-                color: map-get($configuration, smallCardListDetailOverlayIconsColorDesktop);
-              }
             }
 
             .small-card-list-detail-body-text {

--- a/scss/components/lfd/small-h-card.scss
+++ b/scss/components/lfd/small-h-card.scss
@@ -739,16 +739,9 @@
                 color: map-get($configuration, smallHCardDetailSecondDescriptionFontColor);
               }
 
-              .small-h-card-list-detail-button a {
+              .small-h-card-list-detail-button .small-h-card-list-detail-button-image,
+              .small-h-card-list-detail-button .small-h-card-list-detail-button-text {
                 color: map-get($configuration, smallHCardListDetailOverlayIconsColor);
-
-                &:hover,
-                &:focus,
-                &:active,
-                &:active:hover,
-                &:active:focus {
-                  color: map-get($configuration, smallHCardListDetailOverlayIconsColor);
-                }
               }
             }
 
@@ -853,16 +846,9 @@
                   color: map-get($configuration, smallHCardDetailSecondDescriptionFontColorTablet);
                 }
 
-                .small-h-card-list-detail-button a {
+                .small-h-card-list-detail-button .small-h-card-list-detail-button-image,
+                .small-h-card-list-detail-button .small-h-card-list-detail-button-text {
                   color: map-get($configuration, smallHCardListDetailOverlayIconsColorTablet);
-
-                  &:hover,
-                  &:focus,
-                  &:active,
-                  &:active:hover,
-                  &:active:focus {
-                    color: map-get($configuration, smallHCardListDetailOverlayIconsColorTablet);
-                  }
                 }
               }
 
@@ -968,16 +954,9 @@
                   color: map-get($configuration, smallHCardDetailSecondDescriptionFontColorDesktop);
                 }
 
-                .small-h-card-list-detail-button a {
+                .small-h-card-list-detail-button .small-h-card-list-detail-button-image,
+                .small-h-card-list-detail-button .small-h-card-list-detail-button-text {
                   color: map-get($configuration, smallHCardListDetailOverlayIconsColorDesktop);
-
-                  &:hover,
-                  &:focus,
-                  &:active,
-                  &:active:hover,
-                  &:active:focus {
-                    color: map-get($configuration, smallHCardListDetailOverlayIconsColorDesktop);
-                  }
                 }
               }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-158

## Description
Corrected selectors for the detail view icons color

## Screenshots/screencasts
https://share.getcloudapp.com/7KuoBrzk

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
To work correctly needs this [PR](https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/585) as well