### PR TITLE
OD-567 [Fix] Fix Like counter color to match appearance settings

### DIFF
--- a/scss/components/lfd/news-feed.scss
+++ b/scss/components/lfd/news-feed.scss
@@ -854,11 +854,11 @@
           color: map-get($configuration, newsFeedSecondDescriptionFontColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa {
+        .news-feed-like-holder .news-feed-like-wrapper .fa, .count {
           color: map-get($configuration, newsFeedLikeIconColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa.animated {
+        .news-feed-like-holder .news-feed-like-wrapper .fa.animated, .count {
           color: map-get($configuration, newsFeedLikeIconActiveColor);
         }
         

--- a/scss/components/lfd/news-feed.scss
+++ b/scss/components/lfd/news-feed.scss
@@ -854,11 +854,11 @@
           color: map-get($configuration, newsFeedSecondDescriptionFontColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa, .count {
+        .news-feed-like-holder .news-feed-like-wrapper .fa {
           color: map-get($configuration, newsFeedLikeIconColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa.animated, .count {
+        .news-feed-like-holder .news-feed-like-wrapper .fa.animated {
           color: map-get($configuration, newsFeedLikeIconActiveColor);
         }
         

--- a/scss/components/lfd/news-feed.scss
+++ b/scss/components/lfd/news-feed.scss
@@ -854,11 +854,19 @@
           color: map-get($configuration, newsFeedSecondDescriptionFontColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa, .count {
+        .news-feed-like-holder .news-feed-like-wrapper .fa {
           color: map-get($configuration, newsFeedLikeIconColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa.animated, .count {
+        .news-feed-like-holder .news-feed-like-wrapper .fa.animated {
+          color: map-get($configuration, newsFeedLikeIconActiveColor);
+        }
+
+        .news-feed-like-holder .news-feed-like-wrapper.btn-like > span.count {
+          color: map-get($configuration, newsFeedLikeIconColor);
+        }
+
+        .news-feed-like-holder .news-feed-like-wrapper.btn-liked > span.count {
           color: map-get($configuration, newsFeedLikeIconActiveColor);
         }
         

--- a/scss/components/lfd/simple-list.scss
+++ b/scss/components/lfd/simple-list.scss
@@ -805,11 +805,19 @@
         .simple-list-item {
           background-color: map-get($configuration, simpleListItemBackground);
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa, .count {
+          .simple-list-like-holder .simple-list-like-wrapper .fa {
             color: map-get($configuration, simpleListLikeIconColor);
           }
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa.animated, .count {
+          .simple-list-like-holder .simple-list-like-wrapper .fa.animated {
+            color: map-get($configuration, simpleListLikeIconActiveColor);
+          }
+
+          .simple-list-like-holder .simple-list-like-wrapper.btn-like > span.count {
+            color: map-get($configuration, simpleListLikeIconColor);
+          }
+
+          .simple-list-like-holder .simple-list-like-wrapper.btn-liked > span.count {
             color: map-get($configuration, simpleListLikeIconActiveColor);
           }
 

--- a/scss/components/lfd/simple-list.scss
+++ b/scss/components/lfd/simple-list.scss
@@ -805,11 +805,11 @@
         .simple-list-item {
           background-color: map-get($configuration, simpleListItemBackground);
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa, .count {
+          .simple-list-like-holder .simple-list-like-wrapper .fa {
             color: map-get($configuration, simpleListLikeIconColor);
           }
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa.animated, .count {
+          .simple-list-like-holder .simple-list-like-wrapper .fa.animated {
             color: map-get($configuration, simpleListLikeIconActiveColor);
           }
 

--- a/scss/components/lfd/simple-list.scss
+++ b/scss/components/lfd/simple-list.scss
@@ -805,11 +805,11 @@
         .simple-list-item {
           background-color: map-get($configuration, simpleListItemBackground);
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa {
+          .simple-list-like-holder .simple-list-like-wrapper .fa, .count {
             color: map-get($configuration, simpleListLikeIconColor);
           }
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa.animated {
+          .simple-list-like-holder .simple-list-like-wrapper .fa.animated, .count {
             color: map-get($configuration, simpleListLikeIconActiveColor);
           }
 


### PR DESCRIPTION
@sofiiakvasnevska @inna-bieshulia

OD-567 https://weboo.atlassian.net/browse/OD-567

Description
**Problem:** The color of the like counter will not inherit from the color of the like itself.
**Solution:** Styles for the likes count were corrected and inheritance parameters for the counter color were added.

Screenshots/screencasts
https://storyxpress.co/video/ktk0v0y0m2i3n8l33

Backward compatibility
This change is fully backward compatible.

Reviewers
@upplabs-alex-levchenko