### PR TITLE
OD-52 [Fix] Fixed "Add" button color on Agenda

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -36764,7 +36764,7 @@
               },
               {
                 "name": "agendaAddButtonBackground",
-                "default": "#ffffff",
+                "default": "$primaryButtonColor",
                 "columns": 12,
                 "styles": [
                   {
@@ -36790,7 +36790,7 @@
               },
               {
                 "name": "agendaAddButtonIcon",
-                "default": "#666666",
+                "default": "$primaryButtonTextColor",
                 "columns": 12,
                 "styles": [
                   {


### PR DESCRIPTION
@romanyosyfiv

OD-52 https://weboo.atlassian.net/browse/OD-52

## Description
**Problem**: "Add" button color on Agenda was not inherited from the main button
**Solution**: "Add" button color on Agenda inherit from the main button by analogy with other LFT components

## Screenshots/screencasts
https://storyxpress.co/video/kvmb92yhgjl2ah75c

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko