### PR TITLE
OD-639 [Fix] Adjusted appearance settings to the in-app sorting arrows for News Feed and Simple List

### DIFF
--- a/scss/components/lfd/news-feed.scss
+++ b/scss/components/lfd/news-feed.scss
@@ -854,11 +854,11 @@
           color: map-get($configuration, newsFeedSecondDescriptionFontColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa {
+        .news-feed-like-holder .news-feed-like-wrapper .fa, .count {
           color: map-get($configuration, newsFeedLikeIconColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa.animated {
+        .news-feed-like-holder .news-feed-like-wrapper .fa.animated, .count {
           color: map-get($configuration, newsFeedLikeIconActiveColor);
         }
         

--- a/scss/components/lfd/news-feed.scss
+++ b/scss/components/lfd/news-feed.scss
@@ -1446,6 +1446,12 @@
       }
 
       .section-top-wrapper {
+        .list-sort {
+          .fa {
+            color: $highlightColor;
+          }
+        }
+        
         .search-holder {
           input[type="search"] {
             border-color: map-get($configuration, newsFeedSearchFieldBorderColor);

--- a/scss/components/lfd/news-feed.scss
+++ b/scss/components/lfd/news-feed.scss
@@ -854,11 +854,11 @@
           color: map-get($configuration, newsFeedSecondDescriptionFontColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa, .count {
+        .news-feed-like-holder .news-feed-like-wrapper .fa {
           color: map-get($configuration, newsFeedLikeIconColor);
         }
 
-        .news-feed-like-holder .news-feed-like-wrapper .fa.animated, .count {
+        .news-feed-like-holder .news-feed-like-wrapper .fa.animated {
           color: map-get($configuration, newsFeedLikeIconActiveColor);
         }
         

--- a/scss/components/lfd/simple-list.scss
+++ b/scss/components/lfd/simple-list.scss
@@ -679,6 +679,12 @@
       }
 
       .section-top-wrapper {
+        .list-sort {
+          .fa {
+            color: $highlightColor;
+          }
+        }
+
         .search-holder {
           input[type="search"] {
             border-color: map-get($configuration, simpleListSearchFieldBorderColor);

--- a/scss/components/lfd/simple-list.scss
+++ b/scss/components/lfd/simple-list.scss
@@ -805,11 +805,11 @@
         .simple-list-item {
           background-color: map-get($configuration, simpleListItemBackground);
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa, .count {
+          .simple-list-like-holder .simple-list-like-wrapper .fa {
             color: map-get($configuration, simpleListLikeIconColor);
           }
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa.animated, .count {
+          .simple-list-like-holder .simple-list-like-wrapper .fa.animated {
             color: map-get($configuration, simpleListLikeIconActiveColor);
           }
 

--- a/scss/components/lfd/simple-list.scss
+++ b/scss/components/lfd/simple-list.scss
@@ -805,11 +805,11 @@
         .simple-list-item {
           background-color: map-get($configuration, simpleListItemBackground);
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa {
+          .simple-list-like-holder .simple-list-like-wrapper .fa, .count {
             color: map-get($configuration, simpleListLikeIconColor);
           }
 
-          .simple-list-like-holder .simple-list-like-wrapper .fa.animated {
+          .simple-list-like-holder .simple-list-like-wrapper .fa.animated, .count {
             color: map-get($configuration, simpleListLikeIconActiveColor);
           }
 


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-639 https://weboo.atlassian.net/browse/OD-639

##Description
**Problem:** Styles are not added for app sorting arrows that inherit from highlight color.
**Solution:** Styles were added for app sorting arrows that inherit color from highlight color.

## Screenshots/screencasts
https://storyxpress.co/video/kwvwv5v7etgpes0if

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko