### PR TITLE
OD-730 [Fix] Fixed text color for button

### DIFF
--- a/scss/components/chat.scss
+++ b/scss/components/chat.scss
@@ -559,7 +559,7 @@
     .contacts-done-holder .contacts-create {
       background-color: transparent;
       border: 1px solid map-get($configuration, chatButtonBackground);
-      color: map-get($configuration, chatButtonTextColor);
+      color: map-get($configuration, chatButtonBackground);
 
       // Styles for tablet
       @include above($tabletBreakpoint) {


### PR DESCRIPTION
@romanyosyfiv

OD-730 https://weboo.atlassian.net/browse/OD-730

## Description
**Problem**: The default text color of the inactive button was as white as its background.
**Solution**: By default, the text color of the inactive button is use the color of the button border.

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/86256215/152150075-4a8f4507-5c3b-4e61-82dc-e9c90c0fd910.png)

![image](https://user-images.githubusercontent.com/86256215/152150191-67b82878-e3cc-4635-8dcc-973ea5111f93.png)


## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko