### PR TITLE
XOR-82 [FIX] Ensure button style and no row sharing positioning settings update in tablet preview

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -10939,7 +10939,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "primaryButtonWidthTablet",
-                    "default": "auto"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "primaryButtonWidthDesktop",
@@ -41933,7 +41933,7 @@
                 "label": "Search field border color active",
                 "type": "color"
               },
-              
+
               {
                 "name": "simpleListSearchFieldTextColor",
                 "default": "$smallCardSearchFieldTextColor",

--- a/theme.json
+++ b/theme.json
@@ -11150,7 +11150,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "primaryButtonDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "primaryButtonDisplayDesktop",
@@ -23040,7 +23040,7 @@
             ]
           },
           {
-            "description": "Positioning",
+            "description": "Positioning 1111",
             "fields": [
               {
                 "name": "imagePosition",

--- a/theme.json
+++ b/theme.json
@@ -23040,7 +23040,7 @@
             ]
           },
           {
-            "description": "Positioning 1111",
+            "description": "Positioning",
             "fields": [
               {
                 "name": "imagePosition",


### PR DESCRIPTION
**Product areas affected**
Primary Button->Edit appearance settings-> WIDTH AND HEIGHT
Primary Button->Edit appearance settings-> POSITIONING

**What does this PR do?**
button width and no row sharing positioning properties inherit from mobile to tablet and tablet to desktop. In this PR we are updated the width and positioning for tablet preview as per the mobile settings.

**JIRA ticket**
[click here](https://weboo.atlassian.net/browse/XOR-82)

**Result**

https://user-images.githubusercontent.com/102005879/179494407-8daa6ab6-9240-4b60-a4cf-e39a6d49dfc0.mp4

**Checklist**
None

**Testing instructions**
None

**Deployment instructions**
None

**Author concerns**
None