### PR TITLE
XOR-308 [Fix] Ensure button style and no row sharing positioning settings update in tablet preview

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -12788,7 +12788,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "secondaryButtonWidthTablet",
-                    "default": "auto"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "secondaryButtonWidthDesktop",
@@ -12999,7 +12999,7 @@
                 "breakpoints": {
                   "tablet": {
                     "name": "secondaryButtonDisplayTablet",
-                    "default": "inline-block"
+                    "default": "inherit-mobile"
                   },
                   "desktop": {
                     "name": "secondaryButtonDisplayDesktop",


### PR DESCRIPTION
**Product areas affected**
Secondary Button->Edit appearance settings-> WIDTH AND HEIGHT
Secondary Button->Edit appearance settings-> POSITIONING

**What does this PR do?**
button width and no row sharing positioning properties inherit from mobile to tablet and tablet to desktop. In this PR we are updated the width and positioning for tablet preview as per the mobile settings.

**JIRA ticket**
[click here](https://weboo.atlassian.net/browse/XOR-308)

**Result**

https://user-images.githubusercontent.com/102005879/181274743-9a26b4e8-7bb6-4426-80f9-b4b9e55b2b33.mp4

**Checklist**
None

**Testing instructions**
None

**Deployment instructions**
None

**Author concerns**
None