### PR TITLE
XOR-156 [Fix] Ensure Readonly Star field has correct readonly colors

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -1466,12 +1466,16 @@
     }
 
     [_type="flStarRating"] .rating-input ~ .readonly.rating-star .fa {
+      color: map-get($configuration, formReadOnlyBackgroundColor);
+
       &:before {
         -webkit-text-stroke: 1px map-get($configuration, formReadOnlySelectedFillColor);
       }
 
       // Styles for tablet
       @include above($tabletBreakpoint) {
+        color: map-get($configuration, formReadOnlyBackgroundColorTablet);
+
         &:before {
           -webkit-text-stroke: 1px map-get($configuration, formReadOnlySelectedFillColorTablet);
         }
@@ -1479,14 +1483,29 @@
 
       // Styles for desktop
       @include above($desktopBreakpoint) {
+        color: map-get($configuration, formReadOnlyBackgroundColorDesktop);
+
         &:before {
           -webkit-text-stroke: 1px map-get($configuration, formReadOnlySelectedFillColorDesktop);
         }
       }
     }
 
-    [_type="flStarRating"] .rating-input:checked ~ .rating-star .fa,
     [_type="flStarRating"] .rating-input:checked ~ .readonly.rating-star .fa {
+      color: map-get($configuration, formReadOnlySelectedFillColor);
+
+      // Styles for tablet
+      @include above($tabletBreakpoint) {
+        color: map-get($configuration, formReadOnlySelectedFillColorTablet);
+      }
+
+      // Styles for desktop
+      @include above($desktopBreakpoint) {
+        color: map-get($configuration, formReadOnlySelectedFillColorDesktop);
+      }
+    }
+
+    [_type="flStarRating"] .rating-input:checked ~ .rating-star .fa {
       color: map-get($configuration, formStarRatingSelected);
 
       // Styles for tablet
@@ -1497,20 +1516,6 @@
       // Styles for desktop
       @include above($desktopBreakpoint) {
         color: map-get($configuration, formStarRatingSelectedDesktop);
-      }
-    }
-
-    [_type="flStarRating"] .rating-input ~ .readonly.rating-star .fa {
-      color: map-get($configuration, formReadOnlyBackgroundColor);
-
-      // Styles for tablet
-      @include above($tabletBreakpoint) {
-        color: map-get($configuration, formReadOnlyBackgroundColorTablet);
-      }
-
-      // Styles for desktop
-      @include above($desktopBreakpoint) {
-        color: map-get($configuration, formReadOnlyBackgroundColorDesktop);
       }
     }
 


### PR DESCRIPTION
### Product areas affected

Widgets -> Add Form -> Star Field -> Select / Unselect Star ->  Make field read only

### What does this PR do?

Implemented code to apply readonly text background and selected fill color to Readonly star field correctly.

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-156)

### Result

https://user-images.githubusercontent.com/108272606/194356277-679723f4-3514-45b9-808d-7d36d6a4c3e4.mp4

### Checklist

None

### Deployment instructions

None

### Author concerns

None