### PR TITLE
ID-2629 [Fix] Fix container background CSS compilation issue caused by formatters

### DIFF
--- a/scss/components/container.scss
+++ b/scss/components/container.scss
@@ -158,7 +158,7 @@
       @if map-get($configuration, containerBackgroundImage) == "none" {
         background-image: map-get($configuration, containerBackgroundImage);
       } @else {
-        background-image: url(#{map-get($configuration containerBackgroundImage)});
+        background-image: url("#{map-get($configuration, containerBackgroundImage)}");
       }
     } @else if map-get($configuration, containerBackgroundType) == "Color" {
       background-image: none;
@@ -241,7 +241,7 @@
         @if map-get($configuration, containerBackgroundImageTablet) == "none" {
           background-image: map-get($configuration, containerBackgroundImageTablet);
         } @else {
-          background-image: url(#{map-get($configuration containerBackgroundImageTablet)});
+          background-image: url("#{map-get($configuration, containerBackgroundImageTablet)}");
         }
       } @else if map-get($configuration, containerBackgroundTypeTablet) == "Color" {
         background-image: none;
@@ -327,7 +327,7 @@
         @if map-get($configuration, containerBackgroundImageDesktop) == "none" {
           background-image: map-get($configuration, containerBackgroundImageDesktop);
         } @else {
-          background-image: url(#{map-get($configuration containerBackgroundImageDesktop)});
+          background-image: url("#{map-get($configuration, containerBackgroundImageDesktop)}");
         }
       } @else if map-get($configuration, containerBackgroundTypeDesktop) == "Color" {
         background-image: none;

--- a/scss/components/intro-layout.scss
+++ b/scss/components/intro-layout.scss
@@ -23,7 +23,7 @@
     @if map-get($configuration, backgroundImage) == "none" {
       background-image: map-get($configuration, backgroundImage);
     } @else {
-      background-image: url(#{map-get($configuration backgroundImage)});
+      background-image: url("#{map-get($configuration, backgroundImage)}");
     }
   } @else if map-get($configuration, backgroundType) == "Color" {
     background-image: none;

--- a/scss/components/text.scss
+++ b/scss/components/text.scss
@@ -326,7 +326,7 @@
       @if map-get($configuration, textBackgroundImage) == "none" {
         background-image: map-get($configuration, textBackgroundImage);
       } @else {
-        background-image: url(#{map-get($configuration textBackgroundImage)});
+        background-image: url("#{map-get($configuration, textBackgroundImage)}");
       }
     } @else if map-get($configuration, textBackgroundType) == "Color" {
       background-image: none;
@@ -400,7 +400,7 @@
         @if map-get($configuration, textBackgroundImageTablet) == "none" {
           background-image: map-get($configuration, textBackgroundImageTablet);
         } @else {
-          background-image: url(#{map-get($configuration textBackgroundImageTablet)});
+          background-image: url("#{map-get($configuration, textBackgroundImageTablet)}");
         }
       } @else if map-get($configuration, textBackgroundTypeTablet) == "Color" {
         background-image: none;
@@ -479,7 +479,7 @@
         @if map-get($configuration, textBackgroundImageDesktop) == "none" {
           background-image: map-get($configuration, textBackgroundImageDesktop);
         } @else {
-          background-image: url(#{map-get($configuration textBackgroundImageDesktop)});
+          background-image: url("#{map-get($configuration, textBackgroundImageDesktop)}");
         }
       } @else if map-get($configuration, textBackgroundTypeDesktop) == "Color" {
         background-image: none;


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-2629

When `url()` is used alongside `#{}` it appears that it doesn't take `,` within unless `""` is added around it.

This fixes the problem where the `map-get()` wasn't getting a second parameter, which breaks the theme compilation.

I've verified the error no longer occurs and the image background feature for containers is working as expected.