### PR TITLE
XOR-663 [Fix] Ensure dropdown fields are styled correctly when they are invalid

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -612,7 +612,8 @@
         }
       }
 
-      .form-control {
+      .form-control,
+      .select-proxy-display {
         @include borderOnly(
           (
             borderSides: map-get($configuration, formInputBorderErrorSides),


### PR DESCRIPTION
### Product areas affected

Widgets -> Form  -> Dropdown field -> Required -> Submit Form

### What does this PR do?

Implemented fix so that in Form component, when submitting the dropdown fields (required), its border style is matching with error state 

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-663)

### Result

https://user-images.githubusercontent.com/108272606/228447109-0676cdd1-177a-4fe1-aead-bc153d24b609.mp4

### Checklist

none

### Testing instructions

none

### Deployment instructions

none

### Author concerns

none