### PR TITLE
ID-3723 [FIX] Fixing image centering issue

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -23233,10 +23233,12 @@
                 "columns": 12,
                 "logic": {
                   "block": {
-                    "show": ["imageMarginAlign"]
+                    "show": ["imageMarginAlign"],
+                    "showMarginAuto": ["imageMarginLeft", "imageMarginRight"]
                   },
                   "inline-block": {
-                    "hide": ["imageMarginAlign"]
+                    "hide": ["imageMarginAlign"],
+                    "hideMarginAuto": ["imageMarginLeft", "imageMarginRight"]
                   }
                 },
                 "styles": [


### PR DESCRIPTION
I have added new logic to hide and show the `auto` option from `margin-left` and `margin-right` fields

### Result

https://www.loom.com/share/ab02ede13925497d95db04afc40e38b9?sid=8dbad969-9114-4340-8938-c957245c3ece