### PR TITLE
PS-40 [FIX]: Ensures the search field background color transparency is applied to the component.

### DIFF
--- a/scss/components/lfd/small-card.scss
+++ b/scss/components/lfd/small-card.scss
@@ -1359,7 +1359,7 @@
           }
 
           .search-feed {
-            background-color: rgba(map-get($configuration, smallCardSearchFieldBackgroundColor), 1);
+            background-color: map-get($configuration, smallCardSearchFieldBackgroundColor);
             color: map-get($configuration, smallCardSearchFieldTextColor);
 
             &::placeholder {
@@ -1498,10 +1498,7 @@
             }
 
             .search-feed {
-              background-color: rgba(
-                map-get($configuration, smallCardSearchFieldBackgroundColorTablet),
-                1
-              );
+              background-color: map-get($configuration, smallCardSearchFieldBackgroundColorTablet);
               color: map-get($configuration, smallCardSearchFieldTextColorTablet);
 
               &::placeholder {
@@ -1651,10 +1648,7 @@
             }
 
             .search-feed {
-              background-color: rgba(
-                map-get($configuration, smallCardSearchFieldBackgroundColorDesktop),
-                1
-              );
+              background-color: map-get($configuration, smallCardSearchFieldBackgroundColorDesktop);
               color: map-get($configuration, smallCardSearchFieldTextColorDesktop);
 
               &::placeholder {


### PR DESCRIPTION
### Product areas affected

Fliiplet Theme Default

### What does this PR do?

Ensures the search field background color transparency is applied to the component.

### JIRA ticket

[PS-40](https://weboo.atlassian.net/browse/PS-40)

[PS-40]: https://weboo.atlassian.net/browse/PS-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ