### PR TITLE
PS-1633: Ensures Matrix, Reorder list, and Multi-line input inherit appearance settings

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -386,7 +386,8 @@
     }
 
     .form-group {
-      input.form-control {
+      input.form-control,
+      textarea.form-control {
         @include fontOnly(
           (
             fontFamily: map-get($configuration, formTextInputsFontFamily),
@@ -2063,15 +2064,19 @@
       }
     }
 
+    .fl-matrix {
+      border: none;
+    }
+
     .fl-matrix table,
     .fl-matrix table td,
     .fl-matrix table th {
       @include borderOnly(
         (
-          borderSides: $formInputBorderSides,
-          borderWidth: $formInputBorderWidth,
-          borderStyle: $formInputBorderStyle,
-          borderColor: $formInputBorderColor
+          borderSides: map-get($configuration, formInputBorderSides),
+          borderWidth: map-get($configuration, formInputBorderWidth),
+          borderStyle: map-get($configuration, formInputBorderStyle),
+          borderColor: map-get($configuration, formInputBorderColor)
         )
       );
 
@@ -2143,6 +2148,39 @@
         );
 
         color: map-get($configuration, formTextInputsFontColorDesktop);
+      }
+    }
+
+    .list-group-item {
+      @include borderOnly(
+        (
+          borderSides: map-get($configuration, formInputBorderSides),
+          borderWidth: map-get($configuration, formInputBorderWidth),
+          borderStyle: map-get($configuration, formInputBorderStyle),
+          borderColor: map-get($configuration, formInputBorderColor)
+        )
+      );
+
+      @include above($tabletBreakpoint) {
+        @include borderOnly(
+          (
+            borderSides: map-get($configuration, formInputBorderSidesTablet),
+            borderWidth: map-get($configuration, formInputBorderWidthTablet),
+            borderStyle: map-get($configuration, formInputBorderStyleTablet),
+            borderColor: map-get($configuration, formInputBorderColorTablet)
+          )
+        );
+      }
+
+      @include above($desktopBreakpoint) {
+        @include borderOnly(
+          (
+            borderSides: map-get($configuration, formInputBorderSidesDesktop),
+            borderWidth: map-get($configuration, formInputBorderWidthDesktop),
+            borderStyle: map-get($configuration, formInputBorderStyleDesktop),
+            borderColor: map-get($configuration, formInputBorderColorDesktop)
+          )
+        );
       }
     }
   }

--- a/theme.json
+++ b/theme.json
@@ -20443,7 +20443,8 @@
                       ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket",
                       ".fl-matrix table",
                       ".fl-matrix table td",
-                      ".fl-matrix table th"
+                      ".fl-matrix table th",
+                      ".list-group-item"
                     ],
                     "properties": ["border"],
                     "type": "border",
@@ -20480,7 +20481,11 @@
                       ".select-proxy-display>.icon",
                       ".field-signature canvas",
                       ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout",
-                      ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket"
+                      ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket",
+                      ".fl-matrix table",
+                      ".fl-matrix table td",
+                      ".fl-matrix table th",
+                      ".list-group-item"
                     ],
                     "properties": ["border"],
                     "type": "border",
@@ -20516,7 +20521,11 @@
                       ".select-proxy-display>.icon",
                       ".field-signature canvas",
                       ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout",
-                      ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket"
+                      ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket",
+                      ".fl-matrix table",
+                      ".fl-matrix table td",
+                      ".fl-matrix table th",
+                      ".list-group-item"
                     ],
                     "properties": ["border"],
                     "type": "border",
@@ -20553,7 +20562,11 @@
                       ".select-proxy-display>.icon",
                       ".field-signature canvas",
                       ".form-group .mce-tinymce > .mce-container-body.mce-stack-layout",
-                      ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket"
+                      ".form-group .tinymce-mobile-outer-container:not(.tinymce-mobile-fullscreen-maximized) .tinymce-mobile-editor-socket",
+                      ".fl-matrix table",
+                      ".fl-matrix table td",
+                      ".fl-matrix table th",
+                      ".list-group-item"
                     ],
                     "properties": ["border"],
                     "type": "border",
@@ -21138,6 +21151,7 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-group .input-group input.form-control",
+                      ".form-group .input-group textarea.form-control",
                       ".form-group.fl-range-slider .range-slider-labels-label",
                       ".fl-matrix table th"
                     ],
@@ -21165,6 +21179,7 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-group .input-group input.form-control",
+                      ".form-group .input-group textarea.form-control",
                       ".form-group.fl-range-slider .range-slider-labels-label",
                       ".fl-matrix table th"
                     ],
@@ -21193,6 +21208,7 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-group .input-group input.form-control",
+                      ".form-group .input-group textarea.form-control",
                       ".form-group.fl-range-slider .range-slider-labels-label",
                       ".fl-matrix table th"
                     ],
@@ -21220,6 +21236,7 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-group .input-group input.form-control",
+                      ".form-group .input-group textarea.form-control",
                       ".form-group.fl-range-slider .range-slider-labels-label",
                       ".fl-matrix table th"
                     ],
@@ -21247,6 +21264,7 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-group .input-group input.form-control",
+                      ".form-group .input-group textarea.form-control",
                       ".form-group.fl-range-slider .range-slider-labels-label",
                       ".fl-matrix table th"
                     ],
@@ -21274,6 +21292,7 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-group .input-group input.form-control",
+                      ".form-group .input-group textarea.form-control",
                       ".form-group.fl-range-slider .range-slider-labels-label",
                       ".fl-matrix table th"
                     ],
@@ -21303,6 +21322,7 @@
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
                     "selectors": [
                       ".form-group .input-group input.form-control",
+                      ".form-group .input-group textarea.form-control",
                       ".form-group.fl-range-slider .range-slider-labels-label",
                       ".fl-matrix table th"
                     ],
@@ -21334,7 +21354,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-group input::placeholder",
+                    "selectors": [".form-group input::placeholder", ".form-group textarea::placeholder"],
                     "properties": ["font-family"]
                   }
                 ],
@@ -21357,7 +21377,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-group input::placeholder",
+                    "selectors": [".form-group input::placeholder", ".form-group textarea::placeholder"],
                     "properties": ["font-size"]
                   }
                 ],
@@ -21381,7 +21401,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-group input::placeholder",
+                    "selectors": [".form-group input::placeholder", ".form-group textarea::placeholder"],
                     "properties": ["color"]
                   }
                 ],
@@ -21404,7 +21424,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-group input::placeholder",
+                    "selectors": [".form-group input::placeholder", ".form-group textarea::placeholder"],
                     "properties": ["font-weight"]
                   }
                 ],
@@ -21427,7 +21447,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-group input::placeholder",
+                    "selectors": [".form-group input::placeholder", ".form-group textarea::placeholder"],
                     "properties": ["font-style"]
                   }
                 ],
@@ -21450,7 +21470,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-group input::placeholder",
+                    "selectors": [".form-group input::placeholder", ".form-group textarea::placeholder"],
                     "properties": ["text-decoration"]
                   }
                 ],
@@ -21475,7 +21495,7 @@
                 "styles": [
                   {
                     "parentSelector": "[data-widget-package='com.fliplet.form-builder']",
-                    "selectors": ".form-group input::placeholder",
+                    "selectors": [".form-group input::placeholder", ".form-group textarea::placeholder"],
                     "properties": ["line-height"]
                   }
                 ],


### PR DESCRIPTION
## JIRA Issue
https://weboo.atlassian.net/browse/PS-1633

## Summary
- Fix Matrix border styles not inheriting from appearance settings (was using direct SASS variables instead of `map-get($configuration, ...)`)
- Remove `.fl-matrix` wrapper border to prevent double border when appearance border is applied
- Add `.list-group-item` border rules so Reorder list inherits border appearance settings
- Add `textarea.form-control` to text input and placeholder selectors so Multi-line input inherits text and placeholder styles
- Add Matrix and Reorder list selectors to all border settings in theme.json

## Testing
- Set border styles in form appearance settings → Matrix and Reorder list fields now inherit them
- Set text input styles (font, color, size etc.) → Multi-line input now inherits them
- Set placeholder styles → Multi-line input placeholder now inherits them
- Existing fields (single-line input, select, signature) continue to work as before

## Risk Assessment
- Risk Level: LOW
- Files Modified: 2
- Type: Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)