### PR TITLE
PS-1706: Apply agendaListDetailOverlayIconsColor to session buttons in detail overlay

### DIFF
--- a/scss/components/lfd/agenda.scss
+++ b/scss/components/lfd/agenda.scss
@@ -608,6 +608,16 @@
             }
           }
 
+          .agenda-item-bookmark {
+            .session-button {
+              @include responsiveProperty(
+                "color",
+                "agendaListDetailOverlayIconsColor",
+                $configuration
+              );
+            }
+          }
+
           .agenda-item-bookmark-holder {
             .bookmark-wrapper.btn-bookmark .fa {
               @include responsiveProperty("color", "agendaBookmarkIconColor", $configuration);

--- a/scss/components/lfd/agenda.scss
+++ b/scss/components/lfd/agenda.scss
@@ -615,6 +615,14 @@
                 "agendaListDetailOverlayIconsColor",
                 $configuration
               );
+
+              .fa {
+                @include responsiveProperty(
+                  "color",
+                  "agendaListDetailOverlayIconsColor",
+                  $configuration
+                );
+              }
             }
           }
 


### PR DESCRIPTION
## JIRA Issue
https://weboo.atlassian.net/browse/PS-1706

## Summary
- Icons in the agenda LFD detail view were not inheriting the color from the "Detail overlay icons" color setting in LFD theme settings
- Added a CSS rule targeting `.session-button` inside `.agenda-item-bookmark` to apply `agendaListDetailOverlayIconsColor` to both icon and text

## Files Modified
- `scss/components/lfd/agenda.scss` — added `.session-button` color rule inside `.agenda-detail-overlay-panel .agenda-item-content-holder .agenda-item-bookmark`

## Testing
- Enable icons via Agenda Features in LFD settings
- Change "Detail overlay icons" color in LFD theme settings
- Verify both icon and text reflect the chosen color

## Risk Assessment
- Risk Level: LOW
- Files Modified: 1
- Type: Bug fix — additive CSS rule only, scoped to agenda detail overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)