### PR TITLE
release/PS-1706: Agenda LFD detail view icons inherit colour from theme settings

### DIFF
--- a/scss/components/forms.scss
+++ b/scss/components/forms.scss
@@ -880,6 +880,134 @@
       }
     }
 
+    .form-group.fl-typeahead,
+    .form-group.fl-rich-text {
+      .form-control {
+        @include borderOnly(
+          (
+            borderSides: map-get($configuration, formInputBorderSides),
+            borderWidth: map-get($configuration, formInputBorderWidth),
+            borderStyle: map-get($configuration, formInputBorderStyle),
+            borderColor: map-get($configuration, formInputBorderColor)
+          )
+        );
+        border-radius: map-get($configuration, formInputBorderRadius);
+        &:focus-within,
+        &:focus,
+        &.focus {
+          @include borderOnly(
+            (
+              borderSides: map-get($configuration, formInputBorderFocusSides),
+              borderWidth: map-get($configuration, formInputBorderFocusWidth),
+              borderStyle: map-get($configuration, formInputBorderFocusStyle),
+              borderColor: map-get($configuration, formInputBorderFocusColor)
+            )
+          );
+          // Force override against editor defaults
+          border-radius: map-get($configuration, formInputBorderFocusRadius);
+          border: 0 !important;
+          @if map-get($configuration, formInputBorderFocusSides) == "top" {
+            border-top: map-get($configuration, formInputBorderFocusWidth)
+              map-get($configuration, formInputBorderFocusStyle)
+              map-get($configuration, formInputBorderFocusColor) !important;
+          } @else if map-get($configuration, formInputBorderFocusSides) == "right" {
+            border-right: map-get($configuration, formInputBorderFocusWidth)
+              map-get($configuration, formInputBorderFocusStyle)
+              map-get($configuration, formInputBorderFocusColor) !important;
+          } @else if map-get($configuration, formInputBorderFocusSides) == "bottom" {
+            border-bottom: map-get($configuration, formInputBorderFocusWidth)
+              map-get($configuration, formInputBorderFocusStyle)
+              map-get($configuration, formInputBorderFocusColor) !important;
+          } @else if map-get($configuration, formInputBorderFocusSides) == "left" {
+            border-left: map-get($configuration, formInputBorderFocusWidth)
+              map-get($configuration, formInputBorderFocusStyle)
+              map-get($configuration, formInputBorderFocusColor) !important;
+          } @else if map-get($configuration, formInputBorderFocusSides) == "all" {
+            border: map-get($configuration, formInputBorderFocusWidth)
+              map-get($configuration, formInputBorderFocusStyle)
+              map-get($configuration, formInputBorderFocusColor) !important;
+          }
+        }
+
+        // Styles for tablet
+        @include above($tabletBreakpoint) {
+          @include borderOnly(
+            (
+              borderSides: map-get($configuration, formInputBorderSidesTablet),
+              borderWidth: map-get($configuration, formInputBorderWidthTablet),
+              borderStyle: map-get($configuration, formInputBorderStyleTablet),
+              borderColor: map-get($configuration, formInputBorderColorTablet)
+            )
+          );
+          border-radius: map-get($configuration, formInputBorderRadiusTablet);
+
+          &.focus {
+            @include borderOnly(
+              (
+                borderSides: map-get($configuration, formInputBorderFocusSidesTablet),
+                borderWidth: map-get($configuration, formInputBorderFocusWidthTablet),
+                borderStyle: map-get($configuration, formInputBorderFocusStyleTablet),
+                borderColor: map-get($configuration, formInputBorderFocusColorTablet)
+              )
+            );
+            border-radius: map-get($configuration, formInputBorderFocusRadiusTablet);
+          }
+        }
+
+        // Styles for desktop
+        @include above($desktopBreakpoint) {
+          @include borderOnly(
+            (
+              borderSides: map-get($configuration, formInputBorderSidesDesktop),
+              borderWidth: map-get($configuration, formInputBorderWidthDesktop),
+              borderStyle: map-get($configuration, formInputBorderStyleDesktop),
+              borderColor: map-get($configuration, formInputBorderColorDesktop)
+            )
+          );
+          border-radius: map-get($configuration, formInputBorderRadiusDesktop);
+
+          &.focus {
+            @include borderOnly(
+              (
+                borderSides: map-get($configuration, formInputBorderFocusSidesDesktop),
+                borderWidth: map-get($configuration, formInputBorderFocusWidthDesktop),
+                borderStyle: map-get($configuration, formInputBorderFocusStyleDesktop),
+                borderColor: map-get($configuration, formInputBorderFocusColorDesktop)
+              )
+            );
+            border-radius: map-get($configuration, formInputBorderFocusRadiusDesktop);
+          }
+        }
+      }
+    }
+
+    .form-group.fl-typeahead.has-error .selectize-input.form-control,
+    .form-group.fl-typeahead.has-error .selectize-input.form-control.focus {
+      @include borderOnly(
+        (
+          borderSides: map-get($configuration, formInputBorderErrorSides),
+          borderWidth: map-get($configuration, formInputBorderErrorWidth),
+          borderStyle: map-get($configuration, formInputBorderErrorStyle),
+          borderColor: map-get($configuration, formInputBorderErrorColor)
+        )
+      );
+      border-radius: map-get($configuration, formInputBorderErrorRadius);
+    }
+
+    // Rich text error styles (focus lives inside iframe → use :focus-within)
+    .form-group.fl-rich-text.has-error .tox.tox-tinymce.form-control,
+    .form-group.fl-rich-text.has-error .tox.tox-tinymce.form-control:focus-within {
+      @include borderOnly(
+        (
+          borderSides: map-get($configuration, formInputBorderErrorFocusSides),
+          borderWidth: map-get($configuration, formInputBorderErrorFocusWidth),
+          borderStyle: map-get($configuration, formInputBorderErrorFocusStyle),
+          borderColor: map-get($configuration, formInputBorderErrorFocusColor)
+        )
+      );
+      border-radius: map-get($configuration, formInputBorderErrorFocusRadius);
+    }
+
     .form-group.fl-date-picker,
     .form-group.fl-time-picker {
       > .form-control {

--- a/scss/components/lfd/agenda.scss
+++ b/scss/components/lfd/agenda.scss
@@ -608,6 +608,16 @@
             }
           }
 
+          .agenda-item-bookmark {
+            .session-button {
+              @include responsiveProperty(
+                "color",
+                "agendaListDetailOverlayIconsColor",
+                $configuration
+              );
+            }
+          }
+
           .agenda-item-bookmark-holder {
             .bookmark-wrapper.btn-bookmark .fa {
               @include responsiveProperty("color", "agendaBookmarkIconColor", $configuration);

--- a/scss/components/lfd/agenda.scss
+++ b/scss/components/lfd/agenda.scss
@@ -615,6 +615,14 @@
                 "agendaListDetailOverlayIconsColor",
                 $configuration
               );
+
+              .fa {
+                @include responsiveProperty(
+                  "color",
+                  "agendaListDetailOverlayIconsColor",
+                  $configuration
+                );
+              }
             }
           }
 


### PR DESCRIPTION
## JIRA Issue
https://weboo.atlassian.net/browse/PS-1706

## Summary
Icons in the Agenda LFD detail view did not inherit the colour set in the component's appearance settings. They picked up the background colour instead, so they looked invisible unless the background was transparent.

### Changes

#### PS-1706 - Agenda detail overlay icon colour
- [PS-1706](https://weboo.atlassian.net/browse/PS-1706) Apply `agendaListDetailOverlayIconsColor` to `.agenda-item-bookmark .session-button` and its `.fa` icons, so detail-view icons follow the "Detail overlay icons" colour setting across mobile, tablet and desktop.

### Files Changed
- `scss/components/lfd/agenda.scss` — adds a `.agenda-item-bookmark .session-button` rule using `responsiveProperty` with `agendaListDetailOverlayIconsColor`, matching how the sibling `.agenda-item-bookmark-holder` rule already works.

### Branch note
`release/PS-1706` had fallen 3 commits behind `master` and conflicted in `scss/components/forms.scss`. Master was merged in and master's `forms.scss` kept in full — the release branch's copy was a strict subset of it, so nothing was lost and the PS-1633 form appearance work on master is preserved. Net diff against `master` is the 18-line agenda change only.

### Test Plan
- [ ] Drag and drop the Agenda LFD component onto a screen
- [ ] Edit the component's code and update the detail view HTML so the icons are visible
- [ ] Open an agenda item's detail view — icons show in the default colour, not blended into the background
- [ ] Change "Detail overlay icons" colour in the LFD appearance settings — icons take the new colour
- [ ] Check the bookmark icon still uses its own bookmark colour setting and is unchanged
- [ ] Check at mobile, tablet and desktop widths
- [ ] Check form fields (typeahead, rich text, matrix, reorder list, multi-line) still render their border and appearance settings correctly — confirms the `forms.scss` conflict resolution

## Testing notes
1. Add an Agenda component to a screen, edit its code so the detail view icons show, then open an agenda item → the icons should be clearly visible, not the same colour as the panel behind them.
2. In the Agenda component's appearance settings, change the "Detail overlay icons" colour to something obvious like red → reopen an agenda item's detail view and the icons should now be red.
3. Set the detail view background colour to something dark, then something light → the icons should keep the colour you picked in step 2 either way, instead of disappearing into the background.
4. Bookmark an agenda item → the bookmark icon should keep using its own bookmark colour setting and look the same as before this change.
5. View the same agenda item on a phone, a tablet and a desktop browser → the icon colour should be correct on all three.
6. Open a form with a rich text field, a typeahead/autocomplete field, a matrix and a reorder list → all the borders and text styling should look normal, exactly as they did before.

## Risk Assessment
- Risk Level: LOW
- Files Modified: 1
- Type: Bug fix (CSS only, additive rule, no JS or config changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-1706]: https://weboo.atlassian.net/browse/PS-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ