### PR TITLE
release/PS-1706: Agenda LFD detail view icons inherit colour from theme settings

### DIFF
--- a/scss/components/lfd/agenda.scss
+++ b/scss/components/lfd/agenda.scss
@@ -608,6 +608,16 @@
             }
           }
 
+          .agenda-item-bookmark {
+            .session-button {
+              @include responsiveProperty(
+                "color",
+                "agendaListDetailOverlayIconsColor",
+                $configuration
+              );
+            }
+          }
+
           .agenda-item-bookmark-holder {
             .bookmark-wrapper.btn-bookmark .fa {
               @include responsiveProperty("color", "agendaBookmarkIconColor", $configuration);

--- a/scss/components/lfd/agenda.scss
+++ b/scss/components/lfd/agenda.scss
@@ -615,6 +615,14 @@
                 "agendaListDetailOverlayIconsColor",
                 $configuration
               );
+
+              .fa {
+                @include responsiveProperty(
+                  "color",
+                  "agendaListDetailOverlayIconsColor",
+                  $configuration
+                );
+              }
             }
           }
 


### PR DESCRIPTION
## JIRA Issue
https://weboo.atlassian.net/browse/PS-1706

## Summary
Icons in the Agenda LFD detail view did not inherit the colour set in the component's appearance settings. They picked up the background colour instead, so they looked invisible unless the background happened to be transparent.

### Changes

#### PS-1706 - Agenda detail overlay icon colour
- [PS-1706](https://weboo.atlassian.net/browse/PS-1706) Apply `agendaListDetailOverlayIconsColor` to `.agenda-item-bookmark .session-button` and its `.fa` icons, so detail-view icons follow the "Detail overlay icons" colour setting across mobile, tablet and desktop.

### Files Changed
- `scss/components/lfd/agenda.scss` — adds a `.agenda-item-bookmark .session-button` rule using `responsiveProperty` with `agendaListDetailOverlayIconsColor`, matching how the sibling `.agenda-item-bookmark-holder` rule already works.

### Release scope
`git diff --stat production...release/PS-1706` → 1 file, +18/-0. Branch is 3 commits ahead of `production` and 0 behind — all three are PS-1706 work (merged PR #244). No commits from other tickets ride along.

### Test Plan
- [ ] Drag and drop the Agenda LFD component onto a screen
- [ ] Edit the component's code and update the detail view HTML so the icons are visible
- [ ] Open an agenda item's detail view — icons show in the default colour, not blended into the background
- [ ] Change "Detail overlay icons" colour in the LFD appearance settings — icons take the new colour
- [ ] Check the bookmark icon still uses its own bookmark colour setting and is unchanged
- [ ] Check at mobile, tablet and desktop widths

## Testing notes
1. Add an Agenda component to a screen, edit its code so the detail view icons show, then open an agenda item → the icons should be clearly visible, not the same colour as the panel behind them.
2. In the Agenda component's appearance settings, change the "Detail overlay icons" colour to something obvious like red → reopen an agenda item's detail view and the icons should now be red.
3. Set the detail view background colour to something dark, then something light → the icons should keep the colour you picked in step 2 either way, instead of disappearing into the background.
4. Bookmark an agenda item → the bookmark icon should keep using its own bookmark colour setting and look the same as before this change.
5. View the same agenda item on a phone, a tablet and a desktop browser → the icon colour should be correct on all three.

## Risk Assessment
- Risk Level: LOW
- Files Modified: 1
- Type: Bug fix (CSS only, additive rule, no JS or config changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-1706]: https://weboo.atlassian.net/browse/PS-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ